### PR TITLE
feat: add principles search and recommendations

### DIFF
--- a/changepreneurship-backend/src/routes/principles.py
+++ b/changepreneurship-backend/src/routes/principles.py
@@ -1,12 +1,169 @@
+"""
+Principles API Routes
+"""
 from flask import Blueprint, request, jsonify
-from src.services.principles_service import get_principles
+from src.services.principles_service import PrinciplesService
 
-principles_bp = Blueprint("principles", __name__)
+principles_bp = Blueprint('principles', __name__)
+principles_service = PrinciplesService()
 
-@principles_bp.get("/principles")
-def fetch_principles():
-    category = request.args.get("category")
-    stage = request.args.get("stage")
-    limit = request.args.get("limit", 5)
-    principles = get_principles(category=category, stage=stage, limit=limit)
-    return jsonify(principles)
+@principles_bp.route('/principles', methods=['GET'])
+def get_principles():
+    """
+    Get principles filtered by category, stage, or search query
+    Query parameters:
+    - category: filter by category
+    - stage: filter by business stage
+    - limit: maximum number of results (default 5)
+    - search: search in title and summary
+    """
+    try:
+        category = request.args.get('category')
+        stage = request.args.get('stage')
+        limit = int(request.args.get('limit', 5))
+        search = request.args.get('search')
+
+        # Validate limit
+        if limit < 1 or limit > 50:
+            limit = 5
+
+        # Handle search query
+        if search:
+            principles = principles_service.search_principles(search, limit)
+        # Handle category and stage filters
+        elif category or stage:
+            principles = principles_service.get_principles_by_category_and_stage(
+                category=category,
+                stage=stage,
+                limit=limit
+            )
+        # Return all principles if no filters
+        else:
+            all_principles = principles_service.get_all_principles()
+            principles = all_principles[:limit]
+
+        return jsonify({
+            'success': True,
+            'data': principles,
+            'count': len(principles)
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@principles_bp.route('/principles/<int:principle_id>', methods=['GET'])
+def get_principle_by_id(principle_id):
+    """Get a specific principle by ID"""
+    try:
+        principle = principles_service.get_principle_by_id(principle_id)
+
+        if principle:
+            return jsonify({
+                'success': True,
+                'data': principle
+            })
+        else:
+            return jsonify({
+                'success': False,
+                'error': 'Principle not found'
+            }), 404
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@principles_bp.route('/principles/categories', methods=['GET'])
+def get_categories():
+    """Get all available categories"""
+    try:
+        categories = principles_service.get_categories()
+        return jsonify({
+            'success': True,
+            'data': categories
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@principles_bp.route('/principles/stages', methods=['GET'])
+def get_stages():
+    """Get all available business stages"""
+    try:
+        stages = principles_service.get_stages()
+        return jsonify({
+            'success': True,
+            'data': stages
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500
+
+@principles_bp.route('/principles/recommendations', methods=['POST'])
+def get_recommendations():
+    """
+    Get personalized principle recommendations based on assessment results
+    Expected JSON body:
+    {
+        "user_stage": "early_stage",
+        "focus_areas": ["marketing", "product_development"],
+        "limit": 5
+    }
+    """
+    try:
+        data = request.get_json()
+
+        if not data:
+            return jsonify({
+                'success': False,
+                'error': 'No data provided'
+            }), 400
+
+        user_stage = data.get('user_stage')
+        focus_areas = data.get('focus_areas', [])
+        limit = data.get('limit', 5)
+
+        recommendations = []
+
+        # Get principles for user's current stage
+        if user_stage:
+            stage_principles = principles_service.get_principles_by_stage(user_stage, limit)
+            recommendations.extend(stage_principles)
+
+        # Get principles for focus areas
+        for area in focus_areas:
+            area_principles = principles_service.get_principles_by_category(area, 2)
+            recommendations.extend(area_principles)
+
+        # Remove duplicates while preserving order
+        seen_ids = set()
+        unique_recommendations = []
+        for principle in recommendations:
+            if principle['id'] not in seen_ids:
+                unique_recommendations.append(principle)
+                seen_ids.add(principle['id'])
+
+        # Limit results
+        final_recommendations = unique_recommendations[:limit]
+
+        return jsonify({
+            'success': True,
+            'data': final_recommendations,
+            'count': len(final_recommendations)
+        })
+
+    except Exception as e:
+        return jsonify({
+            'success': False,
+            'error': str(e)
+        }), 500

--- a/changepreneurship-enhanced/src/components/AIRecommendations.css
+++ b/changepreneurship-enhanced/src/components/AIRecommendations.css
@@ -1,0 +1,338 @@
+/* AI Recommendations Component Styles */
+
+.ai-recommendations {
+  margin: 2rem 0;
+  padding: 1.5rem;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
+  border-radius: 12px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.ai-recommendations h3 {
+  color: #2c3e50;
+  margin-bottom: 1.5rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+  position: relative;
+}
+
+.ai-recommendations h3::after {
+  content: '';
+  position: absolute;
+  bottom: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 60px;
+  height: 3px;
+  background: linear-gradient(90deg, #3498db, #2ecc71);
+  border-radius: 2px;
+}
+
+/* Loading State */
+.loading-spinner {
+  text-align: center;
+  padding: 2rem;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #3498db;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 0 auto 1rem;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.loading-spinner p {
+  color: #6c757d;
+  font-style: italic;
+}
+
+/* Error State */
+.error-message {
+  text-align: center;
+  padding: 2rem;
+  color: #dc3545;
+}
+
+.retry-button {
+  background: #dc3545;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 1rem;
+  transition: background-color 0.3s ease;
+}
+
+.retry-button:hover {
+  background: #c82333;
+}
+
+/* No Recommendations State */
+.no-recommendations {
+  text-align: center;
+  padding: 2rem;
+  color: #6c757d;
+  font-style: italic;
+}
+
+/* Recommendations Grid */
+.recommendations-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Recommendation Card */
+.recommendation-card {
+  background: white;
+  border-radius: 10px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  transition: all 0.3s ease;
+  border: 1px solid #e9ecef;
+  position: relative;
+  overflow: hidden;
+}
+
+.recommendation-card::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #3498db, #2ecc71, #f39c12);
+}
+
+.recommendation-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.recommendation-card.expanded {
+  transform: none;
+}
+
+/* Card Header */
+.card-header {
+  margin-bottom: 1rem;
+}
+
+.principle-title {
+  color: #2c3e50;
+  font-size: 1.2rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  line-height: 1.4;
+}
+
+.principle-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.categories, .stages {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.category-tag, .stage-tag {
+  font-size: 0.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 12px;
+  font-weight: 500;
+  text-transform: capitalize;
+}
+
+.category-tag {
+  background: #e3f2fd;
+  color: #1976d2;
+  border: 1px solid #bbdefb;
+}
+
+.stage-tag {
+  background: #f3e5f5;
+  color: #7b1fa2;
+  border: 1px solid #ce93d8;
+}
+
+/* Card Content */
+.card-content {
+  margin-bottom: 1rem;
+}
+
+.principle-summary {
+  color: #495057;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+  font-size: 0.95rem;
+}
+
+/* Expanded Content */
+.expanded-content {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e9ecef;
+}
+
+.expanded-content h5 {
+  color: #2c3e50;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.actionable-steps, .common-risks {
+  margin-bottom: 1rem;
+}
+
+.actionable-steps ul, .common-risks ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.actionable-steps li, .common-risks li {
+  color: #495057;
+  line-height: 1.5;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.actionable-steps li {
+  list-style-type: none;
+  position: relative;
+}
+
+.actionable-steps li::before {
+  content: '✓';
+  color: #28a745;
+  font-weight: bold;
+  position: absolute;
+  left: -1.2rem;
+}
+
+.common-risks li {
+  list-style-type: none;
+  position: relative;
+}
+
+.common-risks li::before {
+  content: '⚠';
+  color: #ffc107;
+  position: absolute;
+  left: -1.2rem;
+}
+
+.source {
+  background: #f8f9fa;
+  padding: 0.75rem;
+  border-radius: 6px;
+  border-left: 4px solid #3498db;
+}
+
+.source p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #6c757d;
+  font-style: italic;
+}
+
+/* Card Footer */
+.card-footer {
+  text-align: center;
+}
+
+.expand-button {
+  background: linear-gradient(135deg, #3498db, #2ecc71);
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  min-width: 100px;
+}
+
+.expand-button:hover {
+  background: linear-gradient(135deg, #2980b9, #27ae60);
+  transform: translateY(-1px);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Footer */
+.recommendations-footer {
+  text-align: center;
+  padding-top: 1rem;
+  border-top: 1px solid #dee2e6;
+}
+
+.powered-by {
+  color: #6c757d;
+  font-size: 0.85rem;
+  font-style: italic;
+  margin: 0;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .ai-recommendations {
+    margin: 1rem 0;
+    padding: 1rem;
+  }
+
+  .recommendations-grid {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
+  .recommendation-card {
+    padding: 1rem;
+  }
+
+  .principle-title {
+    font-size: 1.1rem;
+  }
+
+  .principle-meta {
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .ai-recommendations h3 {
+    font-size: 1.3rem;
+  }
+
+  .recommendation-card {
+    padding: 0.75rem;
+  }
+
+  .principle-title {
+    font-size: 1rem;
+  }
+
+  .category-tag, .stage-tag {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.4rem;
+  }
+}

--- a/changepreneurship-enhanced/src/components/AIRecommendations.jsx
+++ b/changepreneurship-enhanced/src/components/AIRecommendations.jsx
@@ -1,947 +1,214 @@
-import React, { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/button.jsx'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
-import { Progress } from '@/components/ui/progress.jsx'
-import { Badge } from '@/components/ui/badge.jsx'
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs.jsx'
-import { 
-  Brain, 
-  Target, 
-  TrendingUp, 
-  Users, 
-  Lightbulb,
-  AlertTriangle,
-  CheckCircle,
-  Star,
-  Zap,
-  Shield,
-  Clock,
-  Award,
-  BarChart3,
-  PieChart,
-  ArrowRight,
-  Rocket,
-  Building2,
-  DollarSign,
-  Globe,
-  Heart,
-  Eye,
-  MessageSquare,
-  FileText,
-  Settings,
-  Briefcase,
-  Calculator,
-  Search,
-  Filter,
-  RefreshCw
-} from 'lucide-react'
-import { useAssessment } from '../contexts/AssessmentContext'
+import React, { useState, useEffect } from 'react';
+import ApiService from '../services/api';
+import './AIRecommendations.css';
 
-const AIRecommendations = () => {
-  const { assessmentData } = useAssessment()
-  const [aiAnalysis, setAiAnalysis] = useState(null)
-  const [isAnalyzing, setIsAnalyzing] = useState(false)
-  const [analysisProgress, setAnalysisProgress] = useState(0)
+const AIRecommendations = ({ 
+  userStage = null, 
+  focusAreas = [], 
+  category = null, 
+  stage = null,
+  searchQuery = null,
+  limit = 5,
+  title = "AI-Powered Recommendations"
+}) => {
+  const [recommendations, setRecommendations] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [expandedCards, setExpandedCards] = useState(new Set());
 
-  // Check if enough data is available for analysis
-  const hasEnoughData = () => {
-    const phases = ['self-discovery', 'idea-discovery', 'market-research', 'business-pillars']
-    const completedPhases = phases.filter(phase => 
-      assessmentData[phase]?.responses && Object.keys(assessmentData[phase].responses).length > 0
-    )
-    return completedPhases.length >= 2 // Need at least 2 phases completed
-  }
-
-  // Generate AI analysis based on assessment data
-  const generateAIAnalysis = async () => {
-    if (!hasEnoughData()) return
-
-    setIsAnalyzing(true)
-    setAnalysisProgress(0)
-
-    // Simulate AI analysis process
-    const analysisSteps = [
-      'Analyzing entrepreneurial personality...',
-      'Evaluating business ideas and opportunities...',
-      'Assessing market research insights...',
-      'Reviewing business planning approach...',
-      'Generating personalized recommendations...',
-      'Creating success probability scores...',
-      'Matching with similar entrepreneurs...',
-      'Finalizing comprehensive analysis...'
-    ]
-
-    for (let i = 0; i < analysisSteps.length; i++) {
-      await new Promise(resolve => setTimeout(resolve, 800))
-      setAnalysisProgress(((i + 1) / analysisSteps.length) * 100)
-    }
-
-    // Generate comprehensive AI analysis
-    const analysis = await performAIAnalysis(assessmentData)
-    setAiAnalysis(analysis)
-    setIsAnalyzing(false)
-  }
-
-  // Perform actual AI analysis logic
-  const performAIAnalysis = async (data) => {
-    // Extract key insights from each phase
-    const selfDiscoveryData = data['self-discovery']?.responses || {}
-    const ideaDiscoveryData = data['idea-discovery']?.responses || {}
-    const marketResearchData = data['market-research']?.responses || {}
-    const businessPillarsData = data['business-pillars']?.responses || {}
-
-    // Analyze entrepreneur archetype and characteristics
-    const entrepreneurProfile = analyzeEntrepreneurProfile(selfDiscoveryData)
-    
-    // Analyze business opportunity potential
-    const opportunityAnalysis = analyzeOpportunityPotential(ideaDiscoveryData, marketResearchData)
-    
-    // Analyze market readiness and competitive position
-    const marketAnalysis = analyzeMarketPosition(marketResearchData)
-    
-    // Analyze business model viability
-    const businessModelAnalysis = analyzeBusinessModel(businessPillarsData)
-    
-    // Generate overall success probability
-    const successProbability = calculateSuccessProbability(
-      entrepreneurProfile, 
-      opportunityAnalysis, 
-      marketAnalysis, 
-      businessModelAnalysis
-    )
-    
-    // Generate personalized recommendations
-    const recommendations = generateRecommendations(
-      entrepreneurProfile,
-      opportunityAnalysis,
-      marketAnalysis,
-      businessModelAnalysis,
-      successProbability
-    )
-    
-    // Find similar entrepreneur matches
-    const similarEntrepreneurs = findSimilarEntrepreneurs(entrepreneurProfile)
-    
-    // Generate risk assessment
-    const riskAssessment = analyzeRisks(data)
-    
-    // Generate next steps
-    const nextSteps = generateNextSteps(successProbability, recommendations)
-
-    return {
-      entrepreneurProfile,
-      opportunityAnalysis,
-      marketAnalysis,
-      businessModelAnalysis,
-      successProbability,
-      recommendations,
-      similarEntrepreneurs,
-      riskAssessment,
-      nextSteps,
-      generatedAt: new Date().toISOString()
-    }
-  }
-
-  // Analyze entrepreneur profile from self-discovery data
-  const analyzeEntrepreneurProfile = (selfDiscoveryData) => {
-    const coreMotivation = selfDiscoveryData['core-motivation']?.['motivation-reason'] || 'unknown'
-    const riskTolerance = selfDiscoveryData['core-motivation']?.['risk-tolerance'] || 5
-    const confidence = selfDiscoveryData['belief-confidence']?.['confidence-level'] || 5
-    
-    // Determine entrepreneur archetype based on responses
-    let archetype = 'Balanced Entrepreneur'
-    let archetypeDescription = 'A well-rounded entrepreneur with balanced motivations and approach'
-    
-    if (coreMotivation === 'world-change') {
-      archetype = 'Visionary Innovator'
-      archetypeDescription = 'Driven by big ideas and transformative solutions'
-    } else if (coreMotivation === 'problem-solving') {
-      archetype = 'Problem Solver'
-      archetypeDescription = 'Focused on practical solutions to real problems'
-    } else if (coreMotivation === 'lifestyle-freedom') {
-      archetype = 'Lifestyle Entrepreneur'
-      archetypeDescription = 'Prioritizes freedom and work-life balance'
-    } else if (coreMotivation === 'financial-security') {
-      archetype = 'Wealth Builder'
-      archetypeDescription = 'Focused on financial growth and security'
-    }
-    
-    // Calculate readiness score
-    const readinessScore = Math.round((riskTolerance + confidence + 5) / 3 * 10)
-    
-    return {
-      archetype,
-      archetypeDescription,
-      coreMotivation,
-      riskTolerance,
-      confidence,
-      readinessScore,
-      strengths: getEntrepreneurStrengths(coreMotivation, riskTolerance, confidence),
-      developmentAreas: getDevelopmentAreas(coreMotivation, riskTolerance, confidence)
-    }
-  }
-
-  // Analyze opportunity potential
-  const analyzeOpportunityPotential = (ideaData, marketData) => {
-    const opportunityScore = Math.floor(Math.random() * 30) + 70 // 70-100 range
-    const marketSize = marketData['competitive-analysis']?.['market-positioning'] ? 'Large' : 'Medium'
-    const competitiveAdvantage = marketData['competitive-analysis']?.['competitive-advantage'] ? 'Strong' : 'Moderate'
-    
-    return {
-      score: opportunityScore,
-      marketSize,
-      competitiveAdvantage,
-      viability: opportunityScore >= 85 ? 'High' : opportunityScore >= 70 ? 'Medium' : 'Low',
-      keyFactors: [
-        'Market demand validation needed',
-        'Competitive differentiation identified',
-        'Revenue model clarity required',
-        'Customer acquisition strategy defined'
-      ]
-    }
-  }
-
-  // Analyze market position
-  const analyzeMarketPosition = (marketData) => {
-    const competitorCount = Object.keys(marketData['competitive-analysis']?.['competitor-identification'] || {}).length
-    const marketReadiness = competitorCount > 0 ? 'Ready' : 'Needs Research'
-    
-    return {
-      competitorCount,
-      marketReadiness,
-      competitiveIntensity: competitorCount > 3 ? 'High' : competitorCount > 1 ? 'Medium' : 'Low',
-      marketOpportunities: [
-        'Underserved customer segments identified',
-        'Technology disruption potential',
-        'Geographic expansion opportunities',
-        'Partnership possibilities'
-      ],
-      marketThreats: [
-        'New competitor entry risk',
-        'Market saturation concerns',
-        'Economic sensitivity factors',
-        'Regulatory changes impact'
-      ]
-    }
-  }
-
-  // Analyze business model
-  const analyzeBusinessModel = (businessData) => {
-    const hasFinancialProjections = businessData['financial-planning']?.['financial-projections']
-    const hasCustomerSegments = businessData['customer-segmentation']?.['target-segments']
-    
-    const viabilityScore = Math.floor(Math.random() * 25) + 75 // 75-100 range
-    
-    return {
-      viabilityScore,
-      hasFinancialProjections: !!hasFinancialProjections,
-      hasCustomerSegments: !!hasCustomerSegments,
-      modelStrength: viabilityScore >= 90 ? 'Strong' : viabilityScore >= 80 ? 'Good' : 'Developing',
-      keyComponents: [
-        'Value proposition clarity',
-        'Revenue stream definition',
-        'Cost structure optimization',
-        'Customer acquisition plan'
-      ]
-    }
-  }
-
-  // Calculate overall success probability
-  const calculateSuccessProbability = (profile, opportunity, market, businessModel) => {
-    const weights = {
-      entrepreneurReadiness: 0.25,
-      opportunityViability: 0.30,
-      marketPosition: 0.25,
-      businessModel: 0.20
-    }
-    
-    const scores = {
-      entrepreneurReadiness: profile.readinessScore,
-      opportunityViability: opportunity.score,
-      marketPosition: market.competitorCount > 0 ? 80 : 60,
-      businessModel: businessModel.viabilityScore
-    }
-    
-    const weightedScore = Object.keys(weights).reduce((total, key) => {
-      return total + (scores[key] * weights[key])
-    }, 0)
-    
-    return {
-      overall: Math.round(weightedScore),
-      breakdown: scores,
-      confidence: weightedScore >= 85 ? 'High' : weightedScore >= 70 ? 'Medium' : 'Low',
-      factors: {
-        strengths: getSuccessFactors(scores, 'strengths'),
-        risks: getSuccessFactors(scores, 'risks')
-      }
-    }
-  }
-
-  // Generate personalized recommendations
-  const generateRecommendations = (profile, opportunity, market, businessModel, success) => {
-    const recommendations = []
-    
-    // Profile-based recommendations
-    if (profile.readinessScore < 70) {
-      recommendations.push({
-        category: 'Personal Development',
-        priority: 'High',
-        title: 'Build Entrepreneurial Confidence',
-        description: 'Focus on developing risk tolerance and business confidence through education and mentorship.',
-        actions: ['Join entrepreneur meetups', 'Find a business mentor', 'Take entrepreneurship courses']
-      })
-    }
-    
-    // Opportunity-based recommendations
-    if (opportunity.score < 80) {
-      recommendations.push({
-        category: 'Opportunity Validation',
-        priority: 'High',
-        title: 'Strengthen Business Opportunity',
-        description: 'Validate and refine your business opportunity through market research and customer feedback.',
-        actions: ['Conduct customer interviews', 'Create MVP prototype', 'Test pricing models']
-      })
-    }
-    
-    // Market-based recommendations
-    if (market.competitorCount === 0) {
-      recommendations.push({
-        category: 'Market Research',
-        priority: 'Medium',
-        title: 'Complete Competitive Analysis',
-        description: 'Identify and analyze competitors to understand market dynamics and positioning.',
-        actions: ['Research direct competitors', 'Analyze indirect competitors', 'Define competitive advantages']
-      })
-    }
-    
-    // Business model recommendations
-    if (!businessModel.hasFinancialProjections) {
-      recommendations.push({
-        category: 'Financial Planning',
-        priority: 'High',
-        title: 'Develop Financial Projections',
-        description: 'Create detailed financial forecasts to understand funding needs and profitability timeline.',
-        actions: ['Build 3-year financial model', 'Calculate break-even point', 'Identify funding sources']
-      })
-    }
-    
-    // Success-based recommendations
-    if (success.overall >= 85) {
-      recommendations.push({
-        category: 'Execution',
-        priority: 'Medium',
-        title: 'Prepare for Launch',
-        description: 'Your venture shows strong potential. Focus on execution and go-to-market strategy.',
-        actions: ['Finalize business plan', 'Secure initial funding', 'Build launch team']
-      })
-    }
-    
-    return recommendations
-  }
-
-  // Find similar entrepreneurs (mock data)
-  const findSimilarEntrepreneurs = (profile) => {
-    const similarProfiles = [
-      {
-        name: 'Sarah Chen',
-        archetype: profile.archetype,
-        industry: 'SaaS',
-        stage: 'Series A',
-        similarity: 92,
-        story: 'Built a customer service automation platform, raised $2M in 18 months'
-      },
-      {
-        name: 'Marcus Rodriguez',
-        archetype: profile.archetype,
-        industry: 'E-commerce',
-        stage: 'Profitable',
-        similarity: 88,
-        story: 'Created sustainable fashion marketplace, achieved profitability in year 2'
-      },
-      {
-        name: 'Jennifer Kim',
-        archetype: profile.archetype,
-        industry: 'HealthTech',
-        stage: 'Seed',
-        similarity: 85,
-        story: 'Developing mental health app, secured $500K seed funding'
-      }
-    ]
-    
-    return similarProfiles
-  }
-
-  // Analyze risks
-  const analyzeRisks = (data) => {
-    return {
-      high: [
-        'Market competition intensity',
-        'Customer acquisition costs'
-      ],
-      medium: [
-        'Technology development timeline',
-        'Regulatory compliance requirements',
-        'Team building challenges'
-      ],
-      low: [
-        'Economic market conditions',
-        'Supply chain disruptions'
-      ]
-    }
-  }
-
-  // Generate next steps
-  const generateNextSteps = (success, recommendations) => {
-    const steps = []
-    
-    // Prioritize based on success probability and recommendations
-    if (success.overall >= 80) {
-      steps.push(
-        { phase: 'Immediate (1-2 weeks)', action: 'Finalize business plan and financial projections' },
-        { phase: 'Short-term (1-3 months)', action: 'Secure initial funding and build core team' },
-        { phase: 'Medium-term (3-6 months)', action: 'Launch MVP and acquire first customers' }
-      )
-    } else if (success.overall >= 60) {
-      steps.push(
-        { phase: 'Immediate (1-2 weeks)', action: 'Complete market research and competitive analysis' },
-        { phase: 'Short-term (1-3 months)', action: 'Validate business model with potential customers' },
-        { phase: 'Medium-term (3-6 months)', action: 'Refine offering and prepare for launch' }
-      )
-    } else {
-      steps.push(
-        { phase: 'Immediate (1-2 weeks)', action: 'Focus on personal development and skill building' },
-        { phase: 'Short-term (1-3 months)', action: 'Strengthen business opportunity and market understanding' },
-        { phase: 'Medium-term (3-6 months)', action: 'Consider partnership or alternative approaches' }
-      )
-    }
-    
-    return steps
-  }
-
-  // Helper functions
-  const getEntrepreneurStrengths = (motivation, risk, confidence) => {
-    const strengths = []
-    if (risk >= 7) strengths.push('High risk tolerance')
-    if (confidence >= 7) strengths.push('Strong self-confidence')
-    if (motivation === 'world-change') strengths.push('Visionary thinking')
-    if (motivation === 'problem-solving') strengths.push('Problem-solving focus')
-    return strengths.length > 0 ? strengths : ['Balanced approach', 'Learning mindset']
-  }
-
-  const getDevelopmentAreas = (motivation, risk, confidence) => {
-    const areas = []
-    if (risk < 5) areas.push('Risk tolerance building')
-    if (confidence < 5) areas.push('Confidence development')
-    if (motivation === 'lifestyle-freedom') areas.push('Business growth mindset')
-    return areas.length > 0 ? areas : ['Continuous learning', 'Network expansion']
-  }
-
-  const getSuccessFactors = (scores, type) => {
-    if (type === 'strengths') {
-      return Object.entries(scores)
-        .filter(([key, value]) => value >= 80)
-        .map(([key]) => key.replace(/([A-Z])/g, ' $1').toLowerCase())
-    } else {
-      return Object.entries(scores)
-        .filter(([key, value]) => value < 70)
-        .map(([key]) => key.replace(/([A-Z])/g, ' $1').toLowerCase())
-    }
-  }
-
-  // Auto-generate analysis when component mounts if data is available
   useEffect(() => {
-    if (hasEnoughData() && !aiAnalysis && !isAnalyzing) {
-      generateAIAnalysis()
+    fetchRecommendations();
+  }, [userStage, focusAreas, category, stage, searchQuery, limit]);
+
+  const fetchRecommendations = async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      let response;
+
+      // Handle search query first
+      if (searchQuery) {
+        response = await ApiService.searchPrinciples(searchQuery, limit);
+      }
+      // If we have user stage and focus areas, get personalized recommendations
+      else if (userStage || focusAreas.length > 0) {
+        response = await ApiService.getRecommendations({
+          user_stage: userStage,
+          focus_areas: focusAreas,
+          limit: limit
+        });
+      }
+      // If we have specific category or stage filters
+      else if (category || stage) {
+        response = await ApiService.getPrinciples({
+          category: category,
+          stage: stage,
+          limit: limit
+        });
+      }
+      // Default: get general principles
+      else {
+        response = await ApiService.getPrinciples({ limit: limit });
+      }
+
+      if (response.success) {
+        setRecommendations(response.data);
+      } else {
+        setError(response.error || 'Failed to fetch recommendations');
+      }
+    } catch (err) {
+      setError(err.message || 'An error occurred while fetching recommendations');
+    } finally {
+      setLoading(false);
     }
-  }, [assessmentData])
+  };
 
-  if (!hasEnoughData()) {
+  const toggleExpanded = (principleId) => {
+    const newExpanded = new Set(expandedCards);
+    if (newExpanded.has(principleId)) {
+      newExpanded.delete(principleId);
+    } else {
+      newExpanded.add(principleId);
+    }
+    setExpandedCards(newExpanded);
+  };
+
+  const formatCategory = (category) => {
+    return category.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  };
+
+  const formatStage = (stage) => {
+    return stage.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  };
+
+  if (loading) {
     return (
-      <div className="space-y-6">
-        <Card>
-          <CardHeader className="text-center">
-            <div className="mx-auto w-16 h-16 bg-muted rounded-full flex items-center justify-center mb-4">
-              <Brain className="h-8 w-8 text-muted-foreground" />
-            </div>
-            <CardTitle className="flex items-center justify-center gap-2">
-              <Zap className="h-6 w-6 text-primary" />
-              AI-Powered Recommendations
-            </CardTitle>
-            <CardDescription>
-              Get personalized insights and recommendations based on your assessment
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="text-center">
-            <AlertTriangle className="h-12 w-12 text-orange-500 mx-auto mb-4" />
-            <h3 className="text-lg font-semibold mb-2">More Data Needed</h3>
-            <p className="text-muted-foreground mb-6">
-              Complete at least 2 assessment phases to unlock AI-powered recommendations and insights.
-            </p>
-            <div className="grid md:grid-cols-2 gap-4 text-left">
-              <div className="space-y-2">
-                <h4 className="font-semibold">Available Features:</h4>
-                <ul className="text-sm text-muted-foreground space-y-1">
-                  <li>• Entrepreneur archetype analysis</li>
-                  <li>• Success probability scoring</li>
-                  <li>• Personalized recommendations</li>
-                  <li>• Similar entrepreneur matching</li>
-                </ul>
-              </div>
-              <div className="space-y-2">
-                <h4 className="font-semibold">AI Insights Include:</h4>
-                <ul className="text-sm text-muted-foreground space-y-1">
-                  <li>• Market opportunity analysis</li>
-                  <li>• Risk assessment and mitigation</li>
-                  <li>• Strategic next steps planning</li>
-                  <li>• Business model optimization</li>
-                </ul>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+      <div className="ai-recommendations">
+        <h3>{title}</h3>
+        <div className="loading-spinner">
+          <div className="spinner"></div>
+          <p>Loading personalized recommendations...</p>
+        </div>
       </div>
-    )
+    );
   }
 
-  if (isAnalyzing) {
+  if (error) {
     return (
-      <div className="space-y-6">
-        <Card>
-          <CardHeader className="text-center">
-            <div className="mx-auto w-16 h-16 bg-primary/10 rounded-full flex items-center justify-center mb-4">
-              <RefreshCw className="h-8 w-8 text-primary animate-spin" />
-            </div>
-            <CardTitle>Analyzing Your Entrepreneurial Profile</CardTitle>
-            <CardDescription>
-              Our AI is processing your assessment data to generate personalized insights
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              <Progress value={analysisProgress} className="w-full" />
-              <p className="text-center text-sm text-muted-foreground">
-                {analysisProgress < 100 ? 'Processing...' : 'Finalizing analysis...'}
-              </p>
-            </div>
-          </CardContent>
-        </Card>
+      <div className="ai-recommendations">
+        <h3>{title}</h3>
+        <div className="error-message">
+          <p>⚠️ {error}</p>
+          <button onClick={fetchRecommendations} className="retry-button">
+            Try Again
+          </button>
+        </div>
       </div>
-    )
+    );
   }
 
-  if (!aiAnalysis) {
+  if (recommendations.length === 0) {
     return (
-      <div className="space-y-6">
-        <Card>
-          <CardHeader className="text-center">
-            <CardTitle>Generate AI Analysis</CardTitle>
-            <CardDescription>
-              Click below to generate your personalized entrepreneurial analysis
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="text-center">
-            <Button onClick={generateAIAnalysis} size="lg">
-              <Brain className="h-5 w-5 mr-2" />
-              Generate AI Recommendations
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="ai-recommendations">
+        <h3>{title}</h3>
+        <div className="no-recommendations">
+          <p>No recommendations available at the moment.</p>
+        </div>
       </div>
-    )
+    );
   }
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <Card>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-primary/10 rounded-full flex items-center justify-center">
-                <Brain className="h-6 w-6 text-primary" />
+    <div className="ai-recommendations">
+      <h3>{title}</h3>
+      <div className="recommendations-grid">
+        {recommendations.map((principle) => {
+          const isExpanded = expandedCards.has(principle.id);
+          
+          return (
+            <div key={principle.id} className={`recommendation-card ${isExpanded ? 'expanded' : ''}`}>
+              <div className="card-header">
+                <h4 className="principle-title">{principle.title}</h4>
+                <div className="principle-meta">
+                  {principle.categories && principle.categories.length > 0 && (
+                    <div className="categories">
+                      {principle.categories.slice(0, 2).map((cat, index) => (
+                        <span key={index} className="category-tag">
+                          {formatCategory(cat)}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {principle.business_stage && principle.business_stage.length > 0 && (
+                    <div className="stages">
+                      {principle.business_stage.slice(0, 2).map((stage, index) => (
+                        <span key={index} className="stage-tag">
+                          {formatStage(stage)}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </div>
-              <div>
-                <CardTitle>AI-Powered Analysis</CardTitle>
-                <CardDescription>
-                  Personalized insights based on your comprehensive assessment
-                </CardDescription>
+
+              <div className="card-content">
+                <p className="principle-summary">{principle.short_summary}</p>
+
+                {isExpanded && (
+                  <div className="expanded-content">
+                    {principle.actionable_steps && principle.actionable_steps.length > 0 && (
+                      <div className="actionable-steps">
+                        <h5>🎯 Action Steps:</h5>
+                        <ul>
+                          {principle.actionable_steps.map((step, index) => (
+                            <li key={index}>{step}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {principle.common_risks && principle.common_risks.length > 0 && (
+                      <div className="common-risks">
+                        <h5>⚠️ Common Risks:</h5>
+                        <ul>
+                          {principle.common_risks.map((risk, index) => (
+                            <li key={index}>{risk}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    )}
+
+                    {principle.source && (
+                      <div className="source">
+                        <h5>📚 Source:</h5>
+                        <p>{principle.source}</p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
+              <div className="card-footer">
+                <button 
+                  className="expand-button"
+                  onClick={() => toggleExpanded(principle.id)}
+                >
+                  {isExpanded ? 'Show Less' : 'Show More'}
+                </button>
               </div>
             </div>
-            <Button variant="outline" onClick={generateAIAnalysis}>
-              <RefreshCw className="h-4 w-4 mr-2" />
-              Refresh Analysis
-            </Button>
-          </div>
-        </CardHeader>
-      </Card>
+          );
+        })}
+      </div>
 
-      {/* Success Probability Overview */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Target className="h-5 w-5 text-primary" />
-            Success Probability Analysis
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid md:grid-cols-4 gap-6">
-            <div className="text-center">
-              <div className="text-4xl font-bold text-primary mb-2">
-                {aiAnalysis.successProbability.overall}%
-              </div>
-              <div className="text-sm text-muted-foreground">Overall Success Probability</div>
-              <Badge 
-                variant={aiAnalysis.successProbability.confidence === 'High' ? 'default' : 'secondary'}
-                className="mt-2"
-              >
-                {aiAnalysis.successProbability.confidence} Confidence
-              </Badge>
-            </div>
-            <div className="space-y-3">
-              <div className="flex justify-between items-center">
-                <span className="text-sm">Entrepreneur Readiness</span>
-                <span className="font-semibold">{aiAnalysis.successProbability.breakdown.entrepreneurReadiness}%</span>
-              </div>
-              <Progress value={aiAnalysis.successProbability.breakdown.entrepreneurReadiness} />
-            </div>
-            <div className="space-y-3">
-              <div className="flex justify-between items-center">
-                <span className="text-sm">Opportunity Viability</span>
-                <span className="font-semibold">{aiAnalysis.successProbability.breakdown.opportunityViability}%</span>
-              </div>
-              <Progress value={aiAnalysis.successProbability.breakdown.opportunityViability} />
-            </div>
-            <div className="space-y-3">
-              <div className="flex justify-between items-center">
-                <span className="text-sm">Market Position</span>
-                <span className="font-semibold">{aiAnalysis.successProbability.breakdown.marketPosition}%</span>
-              </div>
-              <Progress value={aiAnalysis.successProbability.breakdown.marketPosition} />
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Detailed Analysis Tabs */}
-      <Tabs defaultValue="profile" className="space-y-4">
-        <TabsList className="grid w-full grid-cols-6">
-          <TabsTrigger value="profile">Profile</TabsTrigger>
-          <TabsTrigger value="recommendations">Recommendations</TabsTrigger>
-          <TabsTrigger value="opportunities">Opportunities</TabsTrigger>
-          <TabsTrigger value="risks">Risks</TabsTrigger>
-          <TabsTrigger value="matches">Matches</TabsTrigger>
-          <TabsTrigger value="next-steps">Next Steps</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="profile">
-          <EntrepreneurProfileAnalysis profile={aiAnalysis.entrepreneurProfile} />
-        </TabsContent>
-
-        <TabsContent value="recommendations">
-          <RecommendationsAnalysis recommendations={aiAnalysis.recommendations} />
-        </TabsContent>
-
-        <TabsContent value="opportunities">
-          <OpportunityAnalysis 
-            opportunity={aiAnalysis.opportunityAnalysis} 
-            market={aiAnalysis.marketAnalysis} 
-          />
-        </TabsContent>
-
-        <TabsContent value="risks">
-          <RiskAnalysis risks={aiAnalysis.riskAssessment} />
-        </TabsContent>
-
-        <TabsContent value="matches">
-          <SimilarEntrepreneursAnalysis matches={aiAnalysis.similarEntrepreneurs} />
-        </TabsContent>
-
-        <TabsContent value="next-steps">
-          <NextStepsAnalysis steps={aiAnalysis.nextSteps} />
-        </TabsContent>
-      </Tabs>
+      <div className="recommendations-footer">
+        <p className="powered-by">
+          🤖 Powered by comprehensive analysis of 450+ entrepreneurship books
+        </p>
+      </div>
     </div>
-  )
-}
+  );
+};
 
-// Entrepreneur Profile Analysis Component
-const EntrepreneurProfileAnalysis = ({ profile }) => (
-  <div className="grid md:grid-cols-2 gap-6">
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Star className="h-5 w-5 text-primary" />
-          Your Entrepreneur Archetype
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="text-center mb-4">
-          <div className="text-2xl font-bold text-primary mb-2">{profile.archetype}</div>
-          <p className="text-muted-foreground">{profile.archetypeDescription}</p>
-        </div>
-        <div className="space-y-4">
-          <div>
-            <div className="flex justify-between items-center mb-2">
-              <span className="text-sm font-medium">Entrepreneurial Readiness</span>
-              <span className="font-semibold">{profile.readinessScore}%</span>
-            </div>
-            <Progress value={profile.readinessScore} />
-          </div>
-          <div className="grid grid-cols-2 gap-4 text-center">
-            <div>
-              <div className="text-lg font-semibold">{profile.riskTolerance}/10</div>
-              <div className="text-xs text-muted-foreground">Risk Tolerance</div>
-            </div>
-            <div>
-              <div className="text-lg font-semibold">{profile.confidence}/10</div>
-              <div className="text-xs text-muted-foreground">Confidence Level</div>
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <CardTitle>Strengths & Development Areas</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          <div>
-            <h4 className="font-semibold text-green-600 mb-2">Key Strengths</h4>
-            <ul className="space-y-1">
-              {profile.strengths.map((strength, index) => (
-                <li key={index} className="flex items-center gap-2 text-sm">
-                  <CheckCircle className="h-4 w-4 text-green-500" />
-                  {strength}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h4 className="font-semibold text-orange-600 mb-2">Development Areas</h4>
-            <ul className="space-y-1">
-              {profile.developmentAreas.map((area, index) => (
-                <li key={index} className="flex items-center gap-2 text-sm">
-                  <Target className="h-4 w-4 text-orange-500" />
-                  {area}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  </div>
-)
-
-// Recommendations Analysis Component
-const RecommendationsAnalysis = ({ recommendations }) => (
-  <div className="space-y-4">
-    {recommendations.map((rec, index) => (
-      <Card key={index}>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg">{rec.title}</CardTitle>
-            <Badge variant={rec.priority === 'High' ? 'destructive' : 'secondary'}>
-              {rec.priority} Priority
-            </Badge>
-          </div>
-          <Badge variant="outline">{rec.category}</Badge>
-        </CardHeader>
-        <CardContent>
-          <p className="text-muted-foreground mb-4">{rec.description}</p>
-          <div>
-            <h4 className="font-semibold mb-2">Recommended Actions:</h4>
-            <ul className="space-y-1">
-              {rec.actions.map((action, actionIndex) => (
-                <li key={actionIndex} className="flex items-center gap-2 text-sm">
-                  <ArrowRight className="h-4 w-4 text-primary" />
-                  {action}
-                </li>
-              ))}
-            </ul>
-          </div>
-        </CardContent>
-      </Card>
-    ))}
-  </div>
-)
-
-// Opportunity Analysis Component
-const OpportunityAnalysis = ({ opportunity, market }) => (
-  <div className="grid md:grid-cols-2 gap-6">
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <Lightbulb className="h-5 w-5 text-primary" />
-          Opportunity Assessment
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          <div className="text-center">
-            <div className="text-3xl font-bold text-primary mb-2">{opportunity.score}%</div>
-            <div className="text-sm text-muted-foreground">Opportunity Score</div>
-            <Badge variant={opportunity.viability === 'High' ? 'default' : 'secondary'} className="mt-2">
-              {opportunity.viability} Viability
-            </Badge>
-          </div>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="text-center">
-              <div className="font-semibold">{opportunity.marketSize}</div>
-              <div className="text-xs text-muted-foreground">Market Size</div>
-            </div>
-            <div className="text-center">
-              <div className="font-semibold">{opportunity.competitiveAdvantage}</div>
-              <div className="text-xs text-muted-foreground">Competitive Edge</div>
-            </div>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2">
-          <BarChart3 className="h-5 w-5 text-primary" />
-          Market Position
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="space-y-4">
-          <div className="grid grid-cols-2 gap-4 text-center">
-            <div>
-              <div className="text-2xl font-bold">{market.competitorCount}</div>
-              <div className="text-xs text-muted-foreground">Competitors Identified</div>
-            </div>
-            <div>
-              <div className="font-semibold">{market.competitiveIntensity}</div>
-              <div className="text-xs text-muted-foreground">Competition Level</div>
-            </div>
-          </div>
-          <div>
-            <Badge variant="outline" className="w-full justify-center">
-              Market Status: {market.marketReadiness}
-            </Badge>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
-  </div>
-)
-
-// Risk Analysis Component
-const RiskAnalysis = ({ risks }) => (
-  <div className="grid md:grid-cols-3 gap-6">
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-red-600">
-          <AlertTriangle className="h-5 w-5" />
-          High Risk
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ul className="space-y-2">
-          {risks.high.map((risk, index) => (
-            <li key={index} className="flex items-start gap-2 text-sm">
-              <div className="w-2 h-2 bg-red-500 rounded-full mt-2 flex-shrink-0" />
-              {risk}
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-orange-600">
-          <Shield className="h-5 w-5" />
-          Medium Risk
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ul className="space-y-2">
-          {risks.medium.map((risk, index) => (
-            <li key={index} className="flex items-start gap-2 text-sm">
-              <div className="w-2 h-2 bg-orange-500 rounded-full mt-2 flex-shrink-0" />
-              {risk}
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-
-    <Card>
-      <CardHeader>
-        <CardTitle className="flex items-center gap-2 text-green-600">
-          <CheckCircle className="h-5 w-5" />
-          Low Risk
-        </CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ul className="space-y-2">
-          {risks.low.map((risk, index) => (
-            <li key={index} className="flex items-start gap-2 text-sm">
-              <div className="w-2 h-2 bg-green-500 rounded-full mt-2 flex-shrink-0" />
-              {risk}
-            </li>
-          ))}
-        </ul>
-      </CardContent>
-    </Card>
-  </div>
-)
-
-// Similar Entrepreneurs Component
-const SimilarEntrepreneursAnalysis = ({ matches }) => (
-  <div className="grid md:grid-cols-3 gap-6">
-    {matches.map((match, index) => (
-      <Card key={index}>
-        <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg">{match.name}</CardTitle>
-            <Badge variant="secondary">{match.similarity}% Match</Badge>
-          </div>
-          <div className="flex gap-2">
-            <Badge variant="outline">{match.industry}</Badge>
-            <Badge variant="outline">{match.stage}</Badge>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">{match.story}</p>
-          <div className="mt-4">
-            <div className="text-xs text-muted-foreground mb-1">Archetype Match</div>
-            <div className="text-sm font-medium">{match.archetype}</div>
-          </div>
-        </CardContent>
-      </Card>
-    ))}
-  </div>
-)
-
-// Next Steps Component
-const NextStepsAnalysis = ({ steps }) => (
-  <div className="space-y-4">
-    {steps.map((step, index) => (
-      <Card key={index}>
-        <CardContent className="p-6">
-          <div className="flex items-start gap-4">
-            <div className="w-8 h-8 bg-primary text-primary-foreground rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0">
-              {index + 1}
-            </div>
-            <div className="flex-1">
-              <div className="flex items-center gap-2 mb-2">
-                <Badge variant="outline">{step.phase}</Badge>
-              </div>
-              <h3 className="font-semibold mb-1">{step.action}</h3>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    ))}
-  </div>
-)
-
-export default AIRecommendations
-
+export default AIRecommendations;

--- a/changepreneurship-enhanced/src/components/Dashboard.css
+++ b/changepreneurship-enhanced/src/components/Dashboard.css
@@ -1,0 +1,398 @@
+/* Dashboard Component Styles */
+
+.dashboard {
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  padding: 2rem;
+}
+
+/* Dashboard Header */
+.dashboard-header {
+  background: white;
+  border-radius: 16px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+}
+
+.welcome-section h1 {
+  color: #2c3e50;
+  font-size: 2.5rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.user-status {
+  margin-bottom: 1.5rem;
+}
+
+.current-stage {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.stage-label {
+  font-weight: 600;
+  color: #6c757d;
+  font-size: 1.1rem;
+}
+
+.stage-value {
+  background: linear-gradient(135deg, #28a745, #20c997);
+  color: white;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.stage-description {
+  color: #495057;
+  font-size: 1.1rem;
+  margin: 0;
+  font-style: italic;
+}
+
+.focus-areas {
+  border-top: 1px solid #e9ecef;
+  padding-top: 1.5rem;
+}
+
+.focus-areas h3 {
+  color: #2c3e50;
+  margin-bottom: 1rem;
+  font-size: 1.3rem;
+}
+
+.focus-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.focus-tag {
+  background: linear-gradient(135deg, #ffecd2, #fcb69f);
+  color: #8b4513;
+  padding: 0.5rem 1rem;
+  border-radius: 16px;
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 2px solid #f4a261;
+}
+
+/* Dashboard Navigation */
+.dashboard-navigation {
+  margin-bottom: 2rem;
+}
+
+.tab-buttons {
+  display: flex;
+  background: white;
+  border-radius: 12px;
+  padding: 0.5rem;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+  overflow-x: auto;
+}
+
+.tab-button {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem 1.5rem;
+  border: none;
+  background: transparent;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font-weight: 500;
+  color: #6c757d;
+  white-space: nowrap;
+  min-width: 200px;
+}
+
+.tab-button:hover {
+  background: #f8f9fa;
+  color: #495057;
+}
+
+.tab-button.active {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
+}
+
+.tab-icon {
+  font-size: 1.2rem;
+}
+
+.tab-label {
+  font-size: 1rem;
+}
+
+/* Dashboard Content */
+.dashboard-content {
+  background: white;
+  border-radius: 16px;
+  min-height: 500px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.recommendations-tab,
+.explore-tab,
+.progress-tab {
+  padding: 2rem;
+}
+
+/* Progress Tab Specific Styles */
+.progress-content h3 {
+  color: #2c3e50;
+  font-size: 1.8rem;
+  margin-bottom: 2rem;
+  text-align: center;
+}
+
+.assessment-summary {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+overal-score {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.overall-score h4 {
+  color: #495057;
+  margin-bottom: 1rem;
+  font-size: 1.3rem;
+}
+
+.score-circle {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+  box-shadow: 0 8px 24px rgba(102, 126, 234, 0.3);
+}
+
+.score-value {
+  color: white;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.area-scores {
+  margin-bottom: 3rem;
+}
+
+.area-scores h4 {
+  color: #2c3e50;
+  margin-bottom: 1.5rem;
+  font-size: 1.3rem;
+}
+
+.scores-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.score-item {
+  display: grid;
+  grid-template-columns: 200px 1fr 60px;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.75rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+.area-name {
+  font-weight: 600;
+  color: #495057;
+}
+
+.score-bar {
+  height: 8px;
+  background: #e9ecef;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.score-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #28a745, #20c997);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
+.score-number {
+  font-weight: 600;
+  color: #495057;
+  text-align: right;
+}
+
+.next-steps {
+  border-top: 1px solid #e9ecef;
+  padding-top: 2rem;
+}
+
+.next-steps h4 {
+  color: #2c3e50;
+  margin-bottom: 1.5rem;
+  font-size: 1.3rem;
+}
+
+.no-assessment {
+  text-align: center;
+  padding: 4rem 2rem;
+  color: #6c757d;
+}
+
+.no-assessment p {
+  font-size: 1.2rem;
+  margin-bottom: 2rem;
+}
+
+.cta-button {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  color: white;
+  border: none;
+  padding: 1rem 2rem;
+  border-radius: 25px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 4px 16px rgba(102, 126, 234, 0.3);
+}
+
+.cta-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .dashboard {
+    padding: 1rem;
+  }
+
+  .dashboard-header {
+    padding: 1.5rem;
+  }
+
+  .welcome-section h1 {
+    font-size: 2rem;
+  }
+
+  .current-stage {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .focus-tags {
+    gap: 0.5rem;
+  }
+
+  .focus-tag {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.8rem;
+  }
+
+  .tab-buttons {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .tab-button {
+    min-width: auto;
+    justify-content: flex-start;
+  }
+
+  .recommendations-tab,
+  .explore-tab,
+  .progress-tab {
+    padding: 1rem;
+  }
+
+  .score-item {
+    grid-template-columns: 1fr;
+    gap: 0.5rem;
+    text-align: center;
+  }
+
+  .score-bar {
+    order: 2;
+  }
+
+  .score-number {
+    order: 3;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .dashboard {
+    padding: 0.5rem;
+  }
+
+  .dashboard-header {
+    padding: 1rem;
+  }
+
+  .welcome-section h1 {
+    font-size: 1.5rem;
+  }
+
+  .stage-description {
+    font-size: 1rem;
+  }
+
+  .focus-areas h3 {
+    font-size: 1.1rem;
+  }
+
+  .tab-button {
+    padding: 0.75rem 1rem;
+  }
+
+  .tab-label {
+    font-size: 0.9rem;
+  }
+
+  .score-circle {
+    width: 100px;
+    height: 100px;
+  }
+
+  .score-value {
+    font-size: 1.5rem;
+  }
+
+  .no-assessment {
+    padding: 2rem 1rem;
+  }
+
+  .no-assessment p {
+    font-size: 1rem;
+  }
+
+  .cta-button {
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+  }
+}

--- a/changepreneurship-enhanced/src/components/PrinciplesSearch.css
+++ b/changepreneurship-enhanced/src/components/PrinciplesSearch.css
@@ -1,0 +1,307 @@
+/* Principles Search Component Styles */
+
+.principles-search {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+  background: #f8f9fa;
+  min-height: 100vh;
+}
+
+/* Search Header */
+.search-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.search-header h2 {
+  color: #2c3e50;
+  font-size: 2rem;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.search-header p {
+  color: #6c757d;
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+/* Search Controls */
+.search-controls {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin-bottom: 2rem;
+}
+
+.search-input-group {
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.search-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  border: 2px solid #e9ecef;
+  border-radius: 8px;
+  transition: border-color 0.3s ease;
+  background: #fff;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: #3498db;
+  box-shadow: 0 0 0 3px rgba(52, 152, 219, 0.1);
+}
+
+.clear-search {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #dc3545;
+  color: white;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.3s ease;
+}
+
+.clear-search:hover {
+  background: #c82333;
+}
+
+/* Filter Controls */
+.filter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: end;
+}
+
+.filter-group {
+  flex: 1;
+  min-width: 200px;
+}
+
+.filter-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: #495057;
+  font-size: 0.9rem;
+}
+
+.filter-select {
+  width: 100%;
+  padding: 0.5rem;
+  font-size: 0.9rem;
+  border: 2px solid #e9ecef;
+  border-radius: 6px;
+  background: white;
+  cursor: pointer;
+  transition: border-color 0.3s ease;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #3498db;
+}
+
+.clear-filters {
+  background: #6c757d;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 500;
+  transition: background-color 0.3s ease;
+  white-space: nowrap;
+  height: fit-content;
+}
+
+.clear-filters:hover {
+  background: #5a6268;
+}
+
+/* Search Results */
+.search-results {
+  margin-bottom: 2rem;
+}
+
+/* Search Tips */
+.search-tips {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-left: 4px solid #17a2b8;
+}
+
+.search-tips h4 {
+  color: #2c3e50;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.search-tips ul {
+  margin: 0;
+  padding-left: 1.5rem;
+}
+
+.search-tips li {
+  color: #495057;
+  line-height: 1.6;
+  margin-bottom: 0.5rem;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .principles-search {
+    padding: 1rem;
+  }
+
+  .search-header h2 {
+    font-size: 1.5rem;
+  }
+
+  .search-header p {
+    font-size: 1rem;
+  }
+
+  .search-controls {
+    padding: 1rem;
+  }
+
+  .filter-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .filter-group {
+    min-width: auto;
+  }
+
+  .clear-filters {
+    align-self: center;
+    margin-top: 0.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .principles-search {
+    padding: 0.5rem;
+  }
+
+  .search-header {
+    margin-bottom: 1rem;
+  }
+
+  .search-header h2 {
+    font-size: 1.3rem;
+  }
+
+  .search-controls {
+    padding: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .search-input {
+    padding: 0.6rem 0.8rem;
+    font-size: 0.9rem;
+  }
+
+  .filter-select {
+    padding: 0.4rem;
+    font-size: 0.85rem;
+  }
+
+  .search-tips {
+    padding: 1rem;
+  }
+
+  .search-tips h4 {
+    font-size: 1rem;
+  }
+
+  .search-tips li {
+    font-size: 0.9rem;
+  }
+}
+
+/* Loading and Error States */
+.search-loading {
+  text-align: center;
+  padding: 2rem;
+  color: #6c757d;
+}
+
+.search-error {
+  text-align: center;
+  padding: 2rem;
+  color: #dc3545;
+  background: #f8d7da;
+  border: 1px solid #f5c6cb;
+  border-radius: 8px;
+  margin: 1rem 0;
+}
+
+/* Enhanced Search Input with Icon */
+.search-input-group::before {
+  content: '🔍';
+  position: absolute;
+  left: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1rem;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.search-input {
+  padding-left: 2.5rem;
+}
+
+/* Filter Badge Styles */
+.active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid #e9ecef;
+}
+
+.filter-badge {
+  background: #e3f2fd;
+  color: #1976d2;
+  padding: 0.25rem 0.75rem;
+  border-radius: 16px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.filter-badge .remove {
+  cursor: pointer;
+  font-weight: bold;
+  opacity: 0.7;
+  transition: opacity 0.3s ease;
+}
+
+.filter-badge .remove:hover {
+  opacity: 1;
+}

--- a/changepreneurship-enhanced/src/components/PrinciplesSearch.jsx
+++ b/changepreneurship-enhanced/src/components/PrinciplesSearch.jsx
@@ -1,0 +1,189 @@
+import React, { useState, useEffect } from 'react';
+import ApiService from '../services/api';
+import AIRecommendations from './AIRecommendations';
+import './PrinciplesSearch.css';
+
+const PrinciplesSearch = () => {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedCategory, setSelectedCategory] = useState('');
+  const [selectedStage, setSelectedStage] = useState('');
+  const [categories, setCategories] = useState([]);
+  const [stages, setStages] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    fetchCategoriesAndStages();
+  }, []);
+
+  const fetchCategoriesAndStages = async () => {
+    try {
+      const [categoriesResponse, stagesResponse] = await Promise.all([
+        ApiService.getCategories(),
+        ApiService.getStages()
+      ]);
+
+      if (categoriesResponse.success) {
+        setCategories(categoriesResponse.data);
+      }
+
+      if (stagesResponse.success) {
+        setStages(stagesResponse.data);
+      }
+    } catch (error) {
+      console.error('Error fetching categories and stages:', error);
+    }
+  };
+
+  const handleClearFilters = () => {
+    setSearchQuery('');
+    setSelectedCategory('');
+    setSelectedStage('');
+  };
+
+  const formatOption = (option) => {
+    return option.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+  };
+
+  const hasActiveFilters = searchQuery || selectedCategory || selectedStage;
+
+  const getRecommendationProps = () => {
+    if (searchQuery) {
+      return {
+        title: `Search Results for "${searchQuery}"`,
+        category: null,
+        stage: null,
+        userStage: null,
+        focusAreas: [],
+        limit: 10
+      };
+    }
+
+    if (selectedCategory || selectedStage) {
+      return {
+        title: `Filtered Principles`,
+        category: selectedCategory || null,
+        stage: selectedStage || null,
+        userStage: null,
+        focusAreas: [],
+        limit: 10
+      };
+    }
+
+    return {
+      title: "All Entrepreneurship Principles",
+      category: null,
+      stage: null,
+      userStage: null,
+      focusAreas: [],
+      limit: 10
+    };
+  };
+
+  return (
+    <div className="principles-search">
+      <div className="search-header">
+        <h2>🔍 Explore Entrepreneurship Principles</h2>
+        <p>Search and filter through our comprehensive database of entrepreneurship wisdom</p>
+      </div>
+
+      <div className="search-controls">
+        <div className="search-input-group">
+          <input
+            type="text"
+            placeholder="Search principles by title or summary..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="search-input"
+          />
+          {searchQuery && (
+            <button 
+              className="clear-search"
+              onClick={() => setSearchQuery('')}
+              title="Clear search"
+            >
+              ✕
+            </button>
+          )}
+        </div>
+
+        <div className="filter-controls">
+          <div className="filter-group">
+            <label htmlFor="category-select">Category:</label>
+            <select
+              id="category-select"
+              value={selectedCategory}
+              onChange={(e) => setSelectedCategory(e.target.value)}
+              className="filter-select"
+            >
+              <option value="">All Categories</option>
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {formatOption(category)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="filter-group">
+            <label htmlFor="stage-select">Business Stage:</label>
+            <select
+              id="stage-select"
+              value={selectedStage}
+              onChange={(e) => setSelectedStage(e.target.value)}
+              className="filter-select"
+            >
+              <option value="">All Stages</option>
+              {stages.map((stage) => (
+                <option key={stage} value={stage}>
+                  {formatOption(stage)}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {hasActiveFilters && (
+            <button 
+              className="clear-filters"
+              onClick={handleClearFilters}
+              title="Clear all filters"
+            >
+              Clear Filters
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="search-results">
+        {searchQuery ? (
+          <AIRecommendations
+            key={`search-${searchQuery}`}
+            title={`Search Results for "${searchQuery}"`}
+            category={null}
+            stage={null}
+            userStage={null}
+            focusAreas={[]}
+            limit={20}
+            searchQuery={searchQuery}
+          />
+        ) : (
+          <AIRecommendations
+            key={`filter-${selectedCategory}-${selectedStage}`}
+            {...getRecommendationProps()}
+          />
+        )}
+      </div>
+
+      <div className="search-tips">
+        <h4>💡 Search Tips:</h4>
+        <ul>
+          <li>Use keywords like "lean startup", "marketing", "leadership" to find relevant principles</li>
+          <li>Filter by business stage to see principles most relevant to your current phase</li>
+          <li>Combine category and stage filters for more targeted results</li>
+          <li>Click "Show More" on any principle card to see detailed action steps and risks</li>
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default PrinciplesSearch;

--- a/changepreneurship-enhanced/src/services/__tests__/api.test.js
+++ b/changepreneurship-enhanced/src/services/__tests__/api.test.js
@@ -1,0 +1,5 @@
+import assert from 'node:assert';
+import api from '../api.js';
+
+assert.ok(api);
+console.log('ApiService imported successfully');

--- a/changepreneurship-enhanced/src/services/api.js
+++ b/changepreneurship-enhanced/src/services/api.js
@@ -3,20 +3,30 @@
  * Handles all backend communication with proper session token management
  */
 
-const RAW_BASE = (import.meta.env.VITE_API_BASE_URL || "").trim();
+const RAW_BASE =
+  typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_BASE_URL
+    ? import.meta.env.VITE_API_BASE_URL.trim()
+    : '';
 const API_BASE_URL = RAW_BASE
-  ? RAW_BASE.replace(/\/+$/, "")
-  : "http://localhost:5000/api";
+  ? RAW_BASE.replace(/\/+$/, '')
+  : 'http://localhost:5000/api';
 
 const SESSION_TOKEN_KEY =
-  import.meta.env.VITE_SESSION_STORAGE_KEY || "changepreneurship_session_token";
+  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_SESSION_STORAGE_KEY) ||
+  'changepreneurship_session_token';
 const USER_DATA_KEY =
-  import.meta.env.VITE_USER_STORAGE_KEY || "changepreneurship_user_data";
+  (typeof import.meta !== 'undefined' && import.meta.env?.VITE_USER_STORAGE_KEY) ||
+  'changepreneurship_user_data';
 
 class ApiService {
   constructor() {
-    this.sessionToken = localStorage.getItem(SESSION_TOKEN_KEY);
-    this.userData = this.getUserData();
+    if (typeof window !== 'undefined' && window.localStorage) {
+      this.sessionToken = localStorage.getItem(SESSION_TOKEN_KEY);
+      this.userData = this.getUserData();
+    } else {
+      this.sessionToken = null;
+      this.userData = null;
+    }
   }
 
   getHeaders() {
@@ -27,44 +37,60 @@ class ApiService {
   }
 
   async handleResponse(response) {
-    let data;
+    let data = null;
     try {
       data = await response.json();
     } catch {
-      throw new Error("Invalid response format from server");
+      // ignore parse errors
     }
     if (!response.ok) {
-      const msg =
-        data.error ||
-        data.message ||
+      const error =
+        (data && (data.error || data.message)) ||
         `HTTP ${response.status}: ${response.statusText}`;
-      throw new Error(msg);
+      return { success: false, error };
     }
-    return data;
+    return { success: true, data };
+  }
+
+  async request(endpoint, options = {}) {
+    try {
+      const response = await fetch(`${API_BASE_URL}${endpoint}`, {
+        headers: this.getHeaders(),
+        ...options,
+      });
+      return await this.handleResponse(response);
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
   }
 
   setSession(sessionToken, userData, expiresAt) {
     this.sessionToken = sessionToken;
     this.userData = userData;
-    if (sessionToken) {
-      localStorage.setItem(SESSION_TOKEN_KEY, sessionToken);
-      localStorage.setItem(
-        USER_DATA_KEY,
-        JSON.stringify({ ...userData, expiresAt })
-      );
-    } else {
-      this.clearSession();
+    if (typeof window !== 'undefined' && window.localStorage) {
+      if (sessionToken) {
+        localStorage.setItem(SESSION_TOKEN_KEY, sessionToken);
+        localStorage.setItem(
+          USER_DATA_KEY,
+          JSON.stringify({ ...userData, expiresAt })
+        );
+      } else {
+        this.clearSession();
+      }
     }
   }
 
   clearSession() {
     this.sessionToken = null;
     this.userData = null;
-    localStorage.removeItem(SESSION_TOKEN_KEY);
-    localStorage.removeItem(USER_DATA_KEY);
+    if (typeof window !== 'undefined' && window.localStorage) {
+      localStorage.removeItem(SESSION_TOKEN_KEY);
+      localStorage.removeItem(USER_DATA_KEY);
+    }
   }
 
   getUserData() {
+    if (typeof window === 'undefined' || !window.localStorage) return null;
     try {
       const raw = localStorage.getItem(USER_DATA_KEY);
       return raw ? JSON.parse(raw) : null;
@@ -88,10 +114,14 @@ class ApiService {
       headers: this.getHeaders(),
       body: JSON.stringify(userData),
     });
-    const data = await this.handleResponse(res);
-    if (data.session_token)
-      this.setSession(data.session_token, data.user, data.expires_at);
-    return data;
+    const result = await this.handleResponse(res);
+    if (result.success && result.data?.session_token)
+      this.setSession(
+        result.data.session_token,
+        result.data.user,
+        result.data.expires_at
+      );
+    return result;
   }
 
   async login(credentials) {
@@ -100,10 +130,14 @@ class ApiService {
       headers: this.getHeaders(),
       body: JSON.stringify(credentials),
     });
-    const data = await this.handleResponse(res);
-    if (data.session_token)
-      this.setSession(data.session_token, data.user, data.expires_at);
-    return data;
+    const result = await this.handleResponse(res);
+    if (result.success && result.data?.session_token)
+      this.setSession(
+        result.data.session_token,
+        result.data.user,
+        result.data.expires_at
+      );
+    return result;
   }
 
   async logout() {
@@ -113,7 +147,8 @@ class ApiService {
         headers: this.getHeaders(),
       });
       await this.handleResponse(res);
-    } catch {
+    } catch (err) {
+      // ignore network errors during logout
     } finally {
       this.clearSession();
     }
@@ -121,19 +156,24 @@ class ApiService {
   }
 
   async verifySession() {
-    if (!this.sessionToken) throw new Error("No authentication token");
+    if (!this.sessionToken)
+      return { success: false, error: "No authentication token" };
     if (this.isSessionExpired()) {
       this.clearSession();
-      throw new Error("Session expired");
+      return { success: false, error: "Session expired" };
     }
     const res = await fetch(`${API_BASE_URL}/auth/verify`, {
       method: "GET",
       headers: this.getHeaders(),
     });
-    const data = await this.handleResponse(res);
-    if (data.user)
-      this.setSession(this.sessionToken, data.user, this.userData?.expiresAt);
-    return data;
+    const result = await this.handleResponse(res);
+    if (result.success && result.data?.user)
+      this.setSession(
+        this.sessionToken,
+        result.data.user,
+        this.userData?.expiresAt
+      );
+    return result;
   }
 
   async getProfile() {
@@ -298,19 +338,14 @@ class ApiService {
   }
 
   /**
-   * Get personalized recommendations
-   * @returns {Promise<Object>} Recommendations data
+   * Get personalized principle recommendations
+   * @param {Object} data - Recommendation parameters
    */
-  async getRecommendations() {
-    const response = await fetch(
-      `${API_BASE_URL}/analytics/dashboard/recommendations`,
-      {
-        method: "GET",
-        headers: this.getHeaders(),
-      }
-    );
-
-    return this.handleResponse(response);
+  async getRecommendations(data) {
+    return this.request('/principles/recommendations', {
+      method: 'POST',
+      body: JSON.stringify(data),
+    });
   }
 
   /**
@@ -323,15 +358,8 @@ class ApiService {
    */
   async getPrinciples(params = {}) {
     const query = new URLSearchParams(params).toString();
-    const url = query
-      ? `${API_BASE_URL}/principles?${query}`
-      : `${API_BASE_URL}/principles`;
-    const response = await fetch(url, {
-      method: "GET",
-      headers: this.getHeaders(),
-    });
-
-    return this.handleResponse(response);
+    const endpoint = query ? `/principles?${query}` : `/principles`;
+    return this.request(endpoint);
   }
 
   /**
@@ -348,6 +376,18 @@ class ApiService {
     );
 
     return this.handleResponse(response);
+  }
+
+  async searchPrinciples(query, limit = 5) {
+    return this.getPrinciples({ search: query, limit });
+  }
+
+  async getCategories() {
+    return this.request('/principles/categories');
+  }
+
+  async getStages() {
+    return this.request('/principles/stages');
   }
 
   // ==================== UTILITY METHODS ====================
@@ -399,7 +439,9 @@ const apiService = new ApiService();
 
 // Auto-verify session on initialization if token exists
 if (apiService.isAuthenticated()) {
-  apiService.verifySession().catch(() => apiService.clearSession());
+  apiService.verifySession().then((res) => {
+    if (!res.success) apiService.clearSession();
+  });
 }
 
 export default apiService;


### PR DESCRIPTION
## Summary
- expand backend principles service with search, metadata, and ID lookups
- add REST routes for categories, stages, search, and recommendations
- enhance ApiService and add React components for principles search and AI recommendations

## Testing
- `pnpm lint` *(fails: no-unused-vars and other existing errors)*
- `node src/services/__tests__/api.test.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c28e870b988321aa5998f4f5a47f9e