### PR TITLE
fix: persist auth session across refresh

### DIFF
--- a/changepreneurship-enhanced/src/contexts/AuthContext.jsx
+++ b/changepreneurship-enhanced/src/contexts/AuthContext.jsx
@@ -37,9 +37,13 @@ export const AuthProvider = ({ children }) => {
     const initAuth = async () => {
       try {
         if (apiService.isAuthenticated()) {
-          const data = await apiService.verifySession();
-          setUser(data.user);
-          setIsAuthenticated(true);
+          const result = await apiService.verifySession();
+          if (result.success && result.data?.user) {
+            setUser(result.data.user);
+            setIsAuthenticated(true);
+          } else {
+            apiService.clearSession();
+          }
         }
       } catch (error) {
         console.warn("Session verification failed:", error.message);
@@ -53,14 +57,16 @@ export const AuthProvider = ({ children }) => {
   }, []);
   const register = async (userData) => {
     if (BYPASS_AUTH) {
-      return { success: true, data: { user: user } };
+      return { success: true, data: { user } };
     }
 
     try {
-      const data = await apiService.register(userData);
-      setUser(data.user);
-      setIsAuthenticated(true);
-      return { success: true, data };
+      const result = await apiService.register(userData);
+      if (result.success && result.data?.user) {
+        setUser(result.data.user);
+        setIsAuthenticated(true);
+      }
+      return result;
     } catch (error) {
       console.error("Registration error:", error.message);
       return { success: false, error: error.message };
@@ -69,14 +75,16 @@ export const AuthProvider = ({ children }) => {
 
   const login = async (credentials) => {
     if (BYPASS_AUTH) {
-      return { success: true, data: { user: user } };
+      return { success: true, data: { user } };
     }
 
     try {
-      const data = await apiService.login(credentials);
-      setUser(data.user);
-      setIsAuthenticated(true);
-      return { success: true, data };
+      const result = await apiService.login(credentials);
+      if (result.success && result.data?.user) {
+        setUser(result.data.user);
+        setIsAuthenticated(true);
+      }
+      return result;
     } catch (error) {
       console.error("Login error:", error.message);
       return { success: false, error: error.message };
@@ -100,7 +108,7 @@ export const AuthProvider = ({ children }) => {
 
   const getProfile = async () => {
     if (BYPASS_AUTH) {
-      return { success: true, data: { user: user } };
+      return { success: true, data: { user } };
     }
 
     if (!apiService.isAuthenticated()) {
@@ -108,9 +116,11 @@ export const AuthProvider = ({ children }) => {
     }
 
     try {
-      const data = await apiService.getProfile();
-      setUser(data.user);
-      return { success: true, data };
+      const result = await apiService.getProfile();
+      if (result.success && result.data?.user) {
+        setUser(result.data.user);
+      }
+      return result;
     } catch (error) {
       console.error("Profile fetch error:", error.message);
       return { success: false, error: error.message };

--- a/changepreneurship-enhanced/vite.config.js
+++ b/changepreneurship-enhanced/vite.config.js
@@ -2,6 +2,11 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
+import { fileURLToPath } from 'url'
+
+// __dirname is not available in ES module scope, so derive it manually
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- ensure auth context restores session from storage and clears invalid tokens
- fix Vite ES module config by deriving `__dirname` from `import.meta.url`

## Testing
- `npx eslint src/contexts/AuthContext.jsx`
- `npx eslint vite.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2bf00a1f0832196b325ddb690bca7