### PR TITLE
Fix dashboard link and AI recommendations loading

### DIFF
--- a/changepreneurship-enhanced/src/App.jsx
+++ b/changepreneurship-enhanced/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import {
   BrowserRouter as Router,
   Routes,
@@ -62,8 +62,7 @@ import AdaptiveDemo from "./components/AdaptiveDemo";
 import SimpleAdaptiveDemo from "./components/SimpleAdaptiveDemo";
 
 const AssessmentPage = () => {
-  const { assessmentData, updateAssessmentData, currentPhase, updatePhase } =
-    useAssessment();
+  const { assessmentData, currentPhase, updatePhase } = useAssessment();
 
   // Check for URL parameters to set initial phase
   useEffect(() => {
@@ -200,7 +199,7 @@ const AssessmentPage = () => {
           </CardHeader>
           <CardContent>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7 gap-4 mb-6">
-              {phases.map((phase, index) => {
+                {phases.map((phase) => {
                 const Icon = phase.icon;
                 const isCompleted =
                   assessmentData[phase.id]?.completed || false;

--- a/changepreneurship-enhanced/src/components/AIRecommendationsSimple.jsx
+++ b/changepreneurship-enhanced/src/components/AIRecommendationsSimple.jsx
@@ -12,7 +12,13 @@ const AIRecommendationsSimple = () => {
   useEffect(() => {
     apiService
       .getPrinciples()
-      .then(setPrinciples)
+      .then((res) => {
+        if (res.success) {
+          setPrinciples(res.data)
+        } else {
+          setError(res.error || 'Failed to load principles')
+        }
+      })
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
   }, [])

--- a/changepreneurship-enhanced/src/components/LandingPage.jsx
+++ b/changepreneurship-enhanced/src/components/LandingPage.jsx
@@ -190,7 +190,7 @@ const LandingPage = () => {
                     AI Insights
                   </Button>
                 </Link>
-                <Link to="/dashboard">
+                <Link to="/user-dashboard">
                   <Button variant="outline" size="lg" className="text-lg px-8 py-6">
                     View Dashboard
                   </Button>


### PR DESCRIPTION
## Summary
- Point dashboard button in LandingPage to `/user-dashboard`
- Clean up unused imports and variables in App.jsx to satisfy ESLint
- Handle API response in AIRecommendationsSimple so "AI Insights" renders without errors

## Testing
- `npx eslint src/components/AIRecommendationsSimple.jsx`
- `npm run dev` (verified server starts)
- `curl -I http://localhost:5175/ai-recommendations`


------
https://chatgpt.com/codex/tasks/task_e_68c2c34479c483219ba3b1a428a8bcb9