### PR TITLE
feat: add recommendations service

### DIFF
--- a/changepreneurship-backend/src/routes/principles.py
+++ b/changepreneurship-backend/src/routes/principles.py
@@ -133,33 +133,24 @@ def get_recommendations():
         focus_areas = data.get('focus_areas', [])
         limit = data.get('limit', 5)
 
-        recommendations = []
+        # Validate limit
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            limit = 5
+        if limit < 1 or limit > 50:
+            limit = 5
 
-        # Get principles for user's current stage
-        if user_stage:
-            stage_principles = principles_service.get_principles_by_stage(user_stage, limit)
-            recommendations.extend(stage_principles)
-
-        # Get principles for focus areas
-        for area in focus_areas:
-            area_principles = principles_service.get_principles_by_category(area, 2)
-            recommendations.extend(area_principles)
-
-        # Remove duplicates while preserving order
-        seen_ids = set()
-        unique_recommendations = []
-        for principle in recommendations:
-            if principle['id'] not in seen_ids:
-                unique_recommendations.append(principle)
-                seen_ids.add(principle['id'])
-
-        # Limit results
-        final_recommendations = unique_recommendations[:limit]
+        recommendations = principles_service.get_recommendations(
+            user_stage=user_stage,
+            focus_areas=focus_areas,
+            limit=limit,
+        )
 
         return jsonify({
             'success': True,
-            'data': final_recommendations,
-            'count': len(final_recommendations)
+            'data': recommendations,
+            'count': len(recommendations)
         })
 
     except Exception as e:

--- a/changepreneurship-backend/src/services/principles_service.py
+++ b/changepreneurship-backend/src/services/principles_service.py
@@ -143,3 +143,37 @@ class PrinciplesService:
                 stages.add(stage)
 
         return sorted(list(stages))
+
+    def get_recommendations(
+        self,
+        user_stage: str | None,
+        focus_areas: List[str] | None = None,
+        limit: int = 5,
+    ) -> List[Dict]:
+        """Generate personalized principle recommendations."""
+        if not self._principles:
+            return []
+
+        recommendations: List[Dict] = []
+
+        # Recommendations based on user's business stage
+        if user_stage:
+            stage_principles = self.get_principles_by_stage(user_stage, limit)
+            recommendations.extend(stage_principles)
+
+        # Recommendations based on focus areas/categories
+        if focus_areas:
+            for area in focus_areas:
+                area_principles = self.get_principles_by_category(area, 2)
+                recommendations.extend(area_principles)
+
+        # Remove duplicates while preserving order
+        seen_ids = set()
+        unique_recommendations: List[Dict] = []
+        for principle in recommendations:
+            pid = principle.get('id')
+            if pid not in seen_ids:
+                unique_recommendations.append(principle)
+                seen_ids.add(pid)
+
+        return unique_recommendations[:limit]


### PR DESCRIPTION
## Summary
- add `get_recommendations` helper to principles service for stage and focus filtering
- simplify recommendations API route to use service method and validate limits

## Testing
- `python -m pytest`
- `python -m py_compile changepreneurship-backend/src/services/principles_service.py changepreneurship-backend/src/routes/principles.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2d5dcfb8c8321b6390f6e8a1a0980