### PR TITLE
feat: flatten API response data

### DIFF
--- a/changepreneurship-enhanced/src/services/api.js
+++ b/changepreneurship-enhanced/src/services/api.js
@@ -43,13 +43,20 @@ class ApiService {
     } catch {
       // ignore parse errors
     }
+
+    // Flatten standard API responses that wrap payloads in a `data` property
+    const resultData =
+      data && typeof data === "object" && data !== null && "data" in data
+        ? data.data
+        : data;
+
     if (!response.ok) {
       const error =
         (data && (data.error || data.message)) ||
         `HTTP ${response.status}: ${response.statusText}`;
       return { success: false, error };
     }
-    return { success: true, data };
+    return { success: true, data: resultData };
   }
 
   async request(endpoint, options = {}) {
@@ -147,7 +154,7 @@ class ApiService {
         headers: this.getHeaders(),
       });
       await this.handleResponse(res);
-    } catch (err) {
+    } catch {
       // ignore network errors during logout
     } finally {
       this.clearSession();


### PR DESCRIPTION
## Summary
- unwrap nested `data` objects in API responses so callers receive raw payloads
- remove unused variable in logout handler

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 55 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ddedc69c832187eb284b251c0a4a