### PR TITLE
Enable profile and assessment history navigation

### DIFF
--- a/changepreneurship-enhanced/src/App.jsx
+++ b/changepreneurship-enhanced/src/App.jsx
@@ -60,6 +60,8 @@ import LandingPage from "./components/LandingPage";
 import UserDashboard from "./components/dashboard/UserDashboard";
 import AdaptiveDemo from "./components/AdaptiveDemo";
 import SimpleAdaptiveDemo from "./components/SimpleAdaptiveDemo";
+import ProfileSettings from "./components/ProfileSettings";
+import AssessmentHistory from "./components/AssessmentHistory";
 
 const AssessmentPage = () => {
   const { assessmentData, currentPhase, updatePhase } = useAssessment();
@@ -298,6 +300,8 @@ function App() {
               <Route path="/user-dashboard" element={<UserDashboard />} />
               <Route path="/adaptive-demo" element={<AdaptiveDemo />} />
               <Route path="/simple-adaptive" element={<SimpleAdaptiveDemo />} />
+              <Route path="/profile" element={<ProfileSettings />} />
+              <Route path="/assessment-history" element={<AssessmentHistory />} />
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>
           </div>

--- a/changepreneurship-enhanced/src/components/AssessmentHistory.jsx
+++ b/changepreneurship-enhanced/src/components/AssessmentHistory.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const AssessmentHistory = () => {
+  return (
+    <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
+      <div className="max-w-2xl w-full p-8">
+        <h1 className="text-2xl font-bold mb-4">Assessment History</h1>
+        <p>Your completed assessments will appear here.</p>
+      </div>
+    </div>
+  );
+};
+
+export default AssessmentHistory;

--- a/changepreneurship-enhanced/src/components/ProfileSettings.jsx
+++ b/changepreneurship-enhanced/src/components/ProfileSettings.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const ProfileSettings = () => {
+  return (
+    <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
+      <div className="max-w-md w-full p-8">
+        <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
+        <p>Update your account preferences here.</p>
+      </div>
+    </div>
+  );
+};
+
+export default ProfileSettings;

--- a/changepreneurship-enhanced/src/components/UserProfile.jsx
+++ b/changepreneurship-enhanced/src/components/UserProfile.jsx
@@ -1,8 +1,10 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useNavigate } from 'react-router-dom';
 
 const UserProfile = () => {
   const { user, logout } = useAuth();
+  const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
 
@@ -59,7 +61,7 @@ const UserProfile = () => {
             <button
               onClick={() => {
                 setIsDropdownOpen(false);
-                // Navigate to profile page when implemented
+                navigate('/profile');
               }}
               className="w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors duration-200"
             >
@@ -74,7 +76,7 @@ const UserProfile = () => {
             <button
               onClick={() => {
                 setIsDropdownOpen(false);
-                // Navigate to assessment history when implemented
+                navigate('/assessment-history');
               }}
               className="w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors duration-200"
             >


### PR DESCRIPTION
## Summary
- add ProfileSettings and AssessmentHistory components
- wire up navigation from user dropdown
- register new routes for settings and history pages

## Testing
- `pnpm lint` *(fails: no-undef, no-unused-vars, and other eslint issues across repository)*
- `pnpm exec eslint src/App.jsx src/components/UserProfile.jsx src/components/ProfileSettings.jsx src/components/AssessmentHistory.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68c2e654db748321b1a9efe66b4f92b1