### PR TITLE
feat: add profile settings and assessment history

### DIFF
--- a/changepreneurship-enhanced/src/components/AssessmentHistory.jsx
+++ b/changepreneurship-enhanced/src/components/AssessmentHistory.jsx
@@ -1,12 +1,51 @@
-import React from 'react';
+import React from "react";
+import { useAssessment } from "../contexts/AssessmentContext";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.jsx";
+import { Progress } from "@/components/ui/progress.jsx";
+
+const phases = [
+  { id: "self-discovery", name: "Self Discovery" },
+  { id: "idea-discovery", name: "Idea Discovery" },
+  { id: "market-research", name: "Market Research" },
+  { id: "business-pillars", name: "Business Pillars" },
+  { id: "product-concept-testing", name: "Product Concept Testing" },
+  { id: "business-development", name: "Business Development" },
+  { id: "business-prototype-testing", name: "Business Prototype Testing" },
+];
 
 const AssessmentHistory = () => {
+  const { assessmentData } = useAssessment();
+
   return (
     <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
-      <div className="max-w-2xl w-full p-8">
-        <h1 className="text-2xl font-bold mb-4">Assessment History</h1>
-        <p>Your completed assessments will appear here.</p>
-      </div>
+      <Card className="w-full max-w-3xl">
+        <CardHeader>
+          <CardTitle>Assessment History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            {phases.map((phase) => {
+              const data = assessmentData[phase.id] || {};
+              return (
+                <div key={phase.id} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">{phase.name}</span>
+                    <span className="text-sm">
+                      {data.completed ? "Completed" : `${data.progress || 0}%`}
+                    </span>
+                  </div>
+                  <Progress value={data.progress || 0} className="h-2" />
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/changepreneurship-enhanced/src/components/ProfileSettings.jsx
+++ b/changepreneurship-enhanced/src/components/ProfileSettings.jsx
@@ -1,12 +1,141 @@
-import React from 'react';
+import React, { useEffect, useState } from "react";
+import { useAssessment } from "../contexts/AssessmentContext";
+import { useAuth } from "../contexts/AuthContext";
+import { Input } from "@/components/ui/input.jsx";
+import { Label } from "@/components/ui/label.jsx";
+import { Button } from "@/components/ui/button.jsx";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card.jsx";
 
 const ProfileSettings = () => {
+  const { userProfile, updateProfile } = useAssessment();
+  const { user, apiService } = useAuth();
+  const [status, setStatus] = useState("");
+  const [formData, setFormData] = useState({
+    firstName: "",
+    lastName: "",
+    email: "",
+    age: "",
+    location: "",
+    currentRole: "",
+    experience: "",
+  });
+
+  useEffect(() => {
+    setFormData({
+      firstName: userProfile.firstName || "",
+      lastName: userProfile.lastName || "",
+      email: user?.email || userProfile.email || "",
+      age: userProfile.age || "",
+      location: userProfile.location || "",
+      currentRole: userProfile.currentRole || "",
+      experience: userProfile.experience || "",
+    });
+  }, [userProfile, user]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    updateProfile(formData);
+    try {
+      await apiService.updateEntrepreneurProfile(formData);
+      setStatus("Profile updated successfully");
+    } catch {
+      setStatus("Failed to update profile");
+    }
+  };
+
   return (
     <div className="min-h-screen bg-gray-900 text-white flex items-center justify-center">
-      <div className="max-w-md w-full p-8">
-        <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
-        <p>Update your account preferences here.</p>
-      </div>
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>Profile Settings</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="firstName">First Name</Label>
+                <Input
+                  id="firstName"
+                  name="firstName"
+                  value={formData.firstName}
+                  onChange={handleChange}
+                />
+              </div>
+              <div>
+                <Label htmlFor="lastName">Last Name</Label>
+                <Input
+                  id="lastName"
+                  name="lastName"
+                  value={formData.lastName}
+                  onChange={handleChange}
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                name="email"
+                type="email"
+                value={formData.email}
+                onChange={handleChange}
+              />
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="age">Age</Label>
+                <Input
+                  id="age"
+                  name="age"
+                  value={formData.age}
+                  onChange={handleChange}
+                />
+              </div>
+              <div>
+                <Label htmlFor="location">Location</Label>
+                <Input
+                  id="location"
+                  name="location"
+                  value={formData.location}
+                  onChange={handleChange}
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="currentRole">Current Role</Label>
+              <Input
+                id="currentRole"
+                name="currentRole"
+                value={formData.currentRole}
+                onChange={handleChange}
+              />
+            </div>
+            <div>
+              <Label htmlFor="experience">Years of Experience</Label>
+              <Input
+                id="experience"
+                name="experience"
+                value={formData.experience}
+                onChange={handleChange}
+              />
+            </div>
+            {status && <p className="text-sm text-green-400">{status}</p>}
+            <Button type="submit" className="mt-4">
+              Save Changes
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add integrated profile settings form that persists updates
- show assessment history with progress for each phase

## Testing
- `pnpm lint` (fails: many pre-existing lint errors)
- `npx eslint src/components/ProfileSettings.jsx src/components/AssessmentHistory.jsx`
- `node src/services/__tests__/api.test.js`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2eb63466883218cc210c299bf5971