### PR TITLE
Improve navigation and routing resilience

### DIFF
--- a/changepreneurship-enhanced/src/App.jsx
+++ b/changepreneurship-enhanced/src/App.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import {
-  BrowserRouter as Router,
+  HashRouter as Router,
   Routes,
   Route,
   Navigate,
@@ -62,6 +62,7 @@ import AdaptiveDemo from "./components/AdaptiveDemo";
 import SimpleAdaptiveDemo from "./components/SimpleAdaptiveDemo";
 import ProfileSettings from "./components/ProfileSettings";
 import AssessmentHistory from "./components/AssessmentHistory";
+import NavBar from "./components/NavBar";
 
 const AssessmentPage = () => {
   const { assessmentData, currentPhase, updatePhase } = useAssessment();
@@ -290,6 +291,7 @@ function App() {
       <AssessmentProvider>
         <Router>
           <div className="App">
+            <NavBar />
             <Routes>
               <Route path="/" element={<LandingPage />} />
               <Route path="/assessment" element={<AssessmentPage />} />

--- a/changepreneurship-enhanced/src/components/NavBar.jsx
+++ b/changepreneurship-enhanced/src/components/NavBar.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import { Button } from "@/components/ui/button.jsx";
+
+const NavBar = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  if (location.pathname === "/") return null;
+
+  return (
+    <div className="fixed top-4 left-4 z-50 flex gap-2">
+      <Button variant="outline" onClick={() => navigate(-1)}>
+        Back
+      </Button>
+      <Button variant="outline" onClick={() => navigate("/")}>
+        Home
+      </Button>
+    </div>
+  );
+};
+
+export default NavBar;


### PR DESCRIPTION
## Summary
- add NavBar component with Back and Home buttons
- switch to HashRouter to prevent 404 on page refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 55 errors, 20 warnings in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ab2ef1108321a6a1715949f03916