### PR TITLE
feat: add scalable navigation path utilities

### DIFF
--- a/changepreneurship-enhanced/src/App.jsx
+++ b/changepreneurship-enhanced/src/App.jsx
@@ -40,6 +40,10 @@ import {
 } from "lucide-react";
 import "./App.css";
 
+// Navigation utilities
+import { NavigationProvider } from "./contexts/NavigationContext.jsx";
+import QuestionNavigator from "./components/navigation/QuestionNavigator.jsx";
+
 // Contexts
 import { AuthProvider } from "./contexts/AuthContext";
 import {
@@ -289,27 +293,34 @@ function App() {
   return (
     <AuthProvider>
       <AssessmentProvider>
-        <Router>
-          <div className="App">
-            <NavBar />
-            <main className="pt-16">
-              <Routes>
-                <Route path="/" element={<LandingPage />} />
-                <Route path="/assessment" element={<AssessmentPage />} />
-                <Route
-                  path="/ai-recommendations"
-                  element={<AIRecommendationsSimple />}
-                />
-                <Route path="/user-dashboard" element={<UserDashboard />} />
-                <Route path="/adaptive-demo" element={<AdaptiveDemo />} />
-                <Route path="/simple-adaptive" element={<SimpleAdaptiveDemo />} />
-                <Route path="/profile" element={<ProfileSettings />} />
-                <Route path="/assessment-history" element={<AssessmentHistory />} />
-                <Route path="*" element={<Navigate to="/" replace />} />
-              </Routes>
-            </main>
-          </div>
-        </Router>
+        <NavigationProvider>
+          <Router>
+            <div className="App">
+              <NavBar />
+              <main className="pt-16">
+                <Routes>
+                  <Route path="/" element={<LandingPage />} />
+                  <Route path="/assessment" element={<AssessmentPage />} />
+                  <Route
+                    path="/ai-recommendations"
+                    element={<AIRecommendationsSimple />}
+                  />
+                  <Route path="/user-dashboard" element={<UserDashboard />} />
+                  <Route path="/adaptive-demo" element={<AdaptiveDemo />} />
+                  <Route path="/simple-adaptive" element={<SimpleAdaptiveDemo />} />
+                  <Route path="/profile" element={<ProfileSettings />} />
+                  <Route path="/assessment-history" element={<AssessmentHistory />} />
+                  <Route
+                    path="/phase/:phase/tab/:tab/section/:section/question/:question"
+                    element={<QuestionNavigator />}
+                  />
+                  <Route path="/:code" element={<QuestionNavigator />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
+                </Routes>
+              </main>
+            </div>
+          </Router>
+        </NavigationProvider>
       </AssessmentProvider>
     </AuthProvider>
   );

--- a/changepreneurship-enhanced/src/components/navigation/QuestionNavigator.jsx
+++ b/changepreneurship-enhanced/src/components/navigation/QuestionNavigator.jsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState, Suspense } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useNavigation } from '../../contexts/NavigationContext.jsx';
+import { Breadcrumb, BreadcrumbList, BreadcrumbItem, BreadcrumbLink, BreadcrumbPage, BreadcrumbSeparator } from '../ui/breadcrumb.jsx';
+import { Button } from '../ui/button.jsx';
+import { fromCode, toCode, getNext, getPrev } from '../../lib/navigation.js';
+
+const QuestionNavigator = () => {
+  const params = useParams();
+  const navigate = useNavigate();
+  const { structure, path, navigateTo } = useNavigation();
+  const [questions, setQuestions] = useState([]);
+
+  useEffect(() => {
+    if (!structure.length) return;
+    let target;
+    if (params.code) {
+      target = fromCode(params.code);
+    } else if (params.phase) {
+      target = {
+        phase: parseInt(params.phase, 10),
+        tab: parseInt(params.tab, 10),
+        section: parseInt(params.section, 10),
+        question: parseInt(params.question, 10),
+      };
+    }
+    navigateTo(target);
+  }, [params, structure, navigateTo]);
+
+  useEffect(() => {
+    if (!structure.length) return;
+    const long = `/phase/${path.phase}/tab/${path.tab}/section/${path.section}/question/${path.question}`;
+    navigate(long, { replace: true });
+  }, [path, structure, navigate]);
+
+  const phaseNode = structure.find((p) => p.code === path.phase);
+  const tabNode = phaseNode?.tabs.find((t) => t.code === path.tab);
+  const sectionNode = tabNode?.sections.find((s) => s.code === path.section);
+
+  useEffect(() => {
+    if (!sectionNode) return;
+    let mounted = true;
+    import('../../components/assessment/ComprehensiveQuestionBank.jsx').then(({ SELF_DISCOVERY_QUESTIONS }) => {
+      const data = SELF_DISCOVERY_QUESTIONS[sectionNode.id] || [];
+      if (mounted) setQuestions(data);
+    });
+    return () => {
+      mounted = false;
+    };
+  }, [sectionNode]);
+
+  const ITEM_HEIGHT = 60;
+  const [scrollTop, setScrollTop] = useState(0);
+  const onScroll = (e) => setScrollTop(e.currentTarget.scrollTop);
+  const startIndex = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - 5);
+  const endIndex = Math.min(
+    questions.length,
+    Math.ceil((scrollTop + 250) / ITEM_HEIGHT) + 5
+  );
+  const offsetY = startIndex * ITEM_HEIGHT;
+  const visible = questions.slice(startIndex, endIndex);
+
+  const next = getNext(path, structure);
+  const prev = getPrev(path, structure);
+
+  if (!structure.length) return null;
+
+  return (
+    <div className="space-y-4">
+      <Breadcrumb>
+        <BreadcrumbList>
+          <BreadcrumbItem>
+            <BreadcrumbLink onClick={() => navigateTo({ phase: path.phase })}>{phaseNode.title}</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink onClick={() => navigateTo({ phase: path.phase, tab: path.tab })}>{tabNode.title}</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbLink onClick={() => navigateTo({ phase: path.phase, tab: path.tab, section: path.section })}>{sectionNode.title}</BreadcrumbLink>
+          </BreadcrumbItem>
+          <BreadcrumbSeparator />
+          <BreadcrumbItem>
+            <BreadcrumbPage>Question {path.question}</BreadcrumbPage>
+          </BreadcrumbItem>
+        </BreadcrumbList>
+      </Breadcrumb>
+
+      <div className="border rounded h-64 overflow-auto" onScroll={onScroll}>
+        <Suspense fallback={<div>Loading...</div>}>
+          <div style={{ height: questions.length * ITEM_HEIGHT, position: 'relative' }}>
+            <div style={{ transform: `translateY(${offsetY}px)` }}>
+              {visible.map((q) => (
+                <div key={q.id} className="p-4 border-b" style={{ height: ITEM_HEIGHT }}>
+                  {q.question}
+                </div>
+              ))}
+            </div>
+          </div>
+        </Suspense>
+      </div>
+
+      <div className="flex justify-between">
+        <Button variant="outline" onClick={() => navigateTo(prev)}>Prev</Button>
+        <span>{toCode(path)}</span>
+        <Button onClick={() => navigateTo(next)}>Next</Button>
+      </div>
+    </div>
+  );
+};
+
+export default QuestionNavigator;

--- a/changepreneurship-enhanced/src/contexts/NavigationContext.jsx
+++ b/changepreneurship-enhanced/src/contexts/NavigationContext.jsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { fromCode, toCode, normalizePath } from '../lib/navigation.js';
+import { getNavigationStructure } from '../lib/navigation-structure.js';
+
+const NavigationContext = createContext();
+
+export const NavigationProvider = ({ children }) => {
+  const [structure, setStructure] = useState([]);
+  const [path, setPath] = useState({ phase: 1, tab: 1, section: 1, question: 1 });
+
+  useEffect(() => {
+    getNavigationStructure().then(setStructure);
+  }, []);
+
+  useEffect(() => {
+    if (!structure.length) return;
+    const saved = fromCode(localStorage.getItem('lastLocation') || '');
+    const normalized = normalizePath(saved, structure);
+    setPath(normalized);
+  }, [structure]);
+
+  useEffect(() => {
+    if (!structure.length) return;
+    localStorage.setItem('lastLocation', toCode(path));
+  }, [path, structure]);
+
+  const navigateTo = (next) => {
+    setPath(normalizePath(next, structure));
+  };
+
+  return (
+    <NavigationContext.Provider value={{ structure, path, navigateTo }}>
+      {children}
+    </NavigationContext.Provider>
+  );
+};
+
+export const useNavigation = () => useContext(NavigationContext);

--- a/changepreneurship-enhanced/src/lib/navigation-structure.js
+++ b/changepreneurship-enhanced/src/lib/navigation-structure.js
@@ -1,0 +1,31 @@
+export async function getNavigationStructure() {
+  const { SELF_DISCOVERY_QUESTIONS } = await import('../components/assessment/ComprehensiveQuestionBank.jsx');
+  const sections = Object.keys(SELF_DISCOVERY_QUESTIONS).map((key, idx) => ({
+    id: key,
+    code: idx + 1,
+    order: idx + 1,
+    title: key,
+    questions: SELF_DISCOVERY_QUESTIONS[key].map((q, qIdx) => ({
+      id: q.id,
+      code: qIdx + 1,
+      order: qIdx + 1,
+    })),
+  }));
+  return [
+    {
+      id: 'self-discovery',
+      code: 1,
+      order: 1,
+      title: 'Self Discovery',
+      tabs: [
+        {
+          id: 'assessment',
+          code: 1,
+          order: 1,
+          title: 'Assessment',
+          sections,
+        },
+      ],
+    },
+  ];
+}

--- a/changepreneurship-enhanced/src/lib/navigation.js
+++ b/changepreneurship-enhanced/src/lib/navigation.js
@@ -1,0 +1,89 @@
+export function toCode({ phase, tab, section, question }) {
+  return [phase, tab, section, question].join('.');
+}
+
+export function fromCode(code) {
+  const [phase = 1, tab = 1, section = 1, question = 1] =
+    code?.split('.').map((n) => parseInt(n, 10)) || [];
+  return { phase, tab, section, question };
+}
+
+// structure nodes have shape { code:number, order:number, id:string, tabs:[...], sections:[...], questions:[...] }
+export function normalizePath(path, structure) {
+  const phase =
+    structure.find((p) => p.code === (path.phase || path.p)) || structure[0];
+  const tab =
+    phase.tabs.find((t) => t.code === (path.tab || path.t)) || phase.tabs[0];
+  const section =
+    tab.sections.find((s) => s.code === (path.section || path.s)) || tab.sections[0];
+  const question =
+    section.questions.find((q) => q.code === (path.question || path.q)) ||
+    section.questions[0];
+  return {
+    phase: phase.code,
+    tab: tab.code,
+    section: section.code,
+    question: question.code,
+  };
+}
+
+export function getNext(path, structure) {
+  const { phase, tab, section, question } = normalizePath(path, structure);
+  const phaseNode = structure.find((p) => p.code === phase);
+  const tabNode = phaseNode.tabs.find((t) => t.code === tab);
+  const sectionNode = tabNode.sections.find((s) => s.code === section);
+  const qIndex = sectionNode.questions.findIndex((q) => q.code === question);
+  if (qIndex < sectionNode.questions.length - 1) {
+    return { phase, tab, section, question: sectionNode.questions[qIndex + 1].code };
+  }
+  const sIndex = tabNode.sections.findIndex((s) => s.code === section);
+  if (sIndex < tabNode.sections.length - 1) {
+    const nextSection = tabNode.sections[sIndex + 1];
+    return { phase, tab, section: nextSection.code, question: nextSection.questions[0].code };
+  }
+  const tIndex = phaseNode.tabs.findIndex((t) => t.code === tab);
+  if (tIndex < phaseNode.tabs.length - 1) {
+    const nextTab = phaseNode.tabs[tIndex + 1];
+    const nextSection = nextTab.sections[0];
+    return { phase, tab: nextTab.code, section: nextSection.code, question: nextSection.questions[0].code };
+  }
+  const pIndex = structure.findIndex((p) => p.code === phase);
+  if (pIndex < structure.length - 1) {
+    const nextPhase = structure[pIndex + 1];
+    const nextTab = nextPhase.tabs[0];
+    const nextSection = nextTab.sections[0];
+    return { phase: nextPhase.code, tab: nextTab.code, section: nextSection.code, question: nextSection.questions[0].code };
+  }
+  return { phase, tab, section, question };
+}
+
+export function getPrev(path, structure) {
+  const { phase, tab, section, question } = normalizePath(path, structure);
+  const phaseNode = structure.find((p) => p.code === phase);
+  const tabNode = phaseNode.tabs.find((t) => t.code === tab);
+  const sectionNode = tabNode.sections.find((s) => s.code === section);
+  const qIndex = sectionNode.questions.findIndex((q) => q.code === question);
+  if (qIndex > 0) {
+    return { phase, tab, section, question: sectionNode.questions[qIndex - 1].code };
+  }
+  const sIndex = tabNode.sections.findIndex((s) => s.code === section);
+  if (sIndex > 0) {
+    const prevSection = tabNode.sections[sIndex - 1];
+    return { phase, tab, section: prevSection.code, question: prevSection.questions[prevSection.questions.length - 1].code };
+  }
+  const tIndex = phaseNode.tabs.findIndex((t) => t.code === tab);
+  if (tIndex > 0) {
+    const prevTab = phaseNode.tabs[tIndex - 1];
+    const prevSection = prevTab.sections[prevTab.sections.length - 1];
+    return { phase, tab: prevTab.code, section: prevSection.code, question: prevSection.questions[prevSection.questions.length - 1].code };
+  }
+  const pIndex = structure.findIndex((p) => p.code === phase);
+  if (pIndex > 0) {
+    const prevPhase = structure[pIndex - 1];
+    const prevTab = prevPhase.tabs[prevPhase.tabs.length - 1];
+    const prevSection = prevTab.sections[prevTab.sections.length - 1];
+    return { phase: prevPhase.code, tab: prevTab.code, section: prevSection.code, question: prevSection.questions[prevSection.questions.length - 1].code };
+  }
+  return { phase, tab, section, question };
+}
+


### PR DESCRIPTION
## Summary
- add navigation path helpers for 4-tier phase/tab/section/question model
- persist and decode deep-linked question paths
- render breadcrumb and prev/next navigation with lightweight virtualization

## Testing
- `pnpm lint` *(fails: 78 problems)*
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_68c41fc1c73c8321afc23513b71ec5d6