### PR TITLE
feat: expand navigation model with deep links

### DIFF
--- a/changepreneurship-enhanced/src/components/navigation/QuestionNavigator.jsx
+++ b/changepreneurship-enhanced/src/components/navigation/QuestionNavigator.jsx
@@ -8,7 +8,7 @@ import { fromCode, toCode, getNext, getPrev } from '../../lib/navigation.js';
 const QuestionNavigator = () => {
   const params = useParams();
   const navigate = useNavigate();
-  const { structure, path, navigateTo } = useNavigation();
+  const { structure, path, navigateTo, markVisited } = useNavigation();
   const [questions, setQuestions] = useState([]);
 
   useEffect(() => {
@@ -36,6 +36,11 @@ const QuestionNavigator = () => {
   const phaseNode = structure.find((p) => p.code === path.phase);
   const tabNode = phaseNode?.tabs.find((t) => t.code === path.tab);
   const sectionNode = tabNode?.sections.find((s) => s.code === path.section);
+  const questionNode = sectionNode?.questions.find((q) => q.code === path.question);
+
+  useEffect(() => {
+    if (questionNode) markVisited(questionNode.id);
+  }, [questionNode, markVisited]);
 
   useEffect(() => {
     if (!sectionNode) return;
@@ -60,8 +65,14 @@ const QuestionNavigator = () => {
   const offsetY = startIndex * ITEM_HEIGHT;
   const visible = questions.slice(startIndex, endIndex);
 
-  const next = getNext(path, structure);
-  const prev = getPrev(path, structure);
+  const nextPhase = getNext(path, structure, 'phase');
+  const prevPhase = getPrev(path, structure, 'phase');
+  const nextTab = getNext(path, structure, 'tab');
+  const prevTab = getPrev(path, structure, 'tab');
+  const nextSection = getNext(path, structure, 'section');
+  const prevSection = getPrev(path, structure, 'section');
+  const nextQuestion = getNext(path, structure, 'question');
+  const prevQuestion = getPrev(path, structure, 'question');
 
   if (!structure.length) return null;
 
@@ -101,10 +112,32 @@ const QuestionNavigator = () => {
         </Suspense>
       </div>
 
-      <div className="flex justify-between">
-        <Button variant="outline" onClick={() => navigateTo(prev)}>Prev</Button>
-        <span>{toCode(path)}</span>
-        <Button onClick={() => navigateTo(next)}>Next</Button>
+      <div className="space-y-2">
+        <div className="flex justify-between">
+          <Button variant="outline" onClick={() => navigateTo(prevPhase)}>
+            Prev Phase
+          </Button>
+          <Button onClick={() => navigateTo(nextPhase)}>Next Phase</Button>
+        </div>
+        <div className="flex justify-between">
+          <Button variant="outline" onClick={() => navigateTo(prevTab)}>
+            Prev Tab
+          </Button>
+          <Button onClick={() => navigateTo(nextTab)}>Next Tab</Button>
+        </div>
+        <div className="flex justify-between">
+          <Button variant="outline" onClick={() => navigateTo(prevSection)}>
+            Prev Section
+          </Button>
+          <Button onClick={() => navigateTo(nextSection)}>Next Section</Button>
+        </div>
+        <div className="flex justify-between">
+          <Button variant="outline" onClick={() => navigateTo(prevQuestion)}>
+            Prev Question
+          </Button>
+          <span>{toCode(path)}</span>
+          <Button onClick={() => navigateTo(nextQuestion)}>Next Question</Button>
+        </div>
       </div>
     </div>
   );

--- a/changepreneurship-enhanced/src/contexts/NavigationContext.jsx
+++ b/changepreneurship-enhanced/src/contexts/NavigationContext.jsx
@@ -7,6 +7,13 @@ const NavigationContext = createContext();
 export const NavigationProvider = ({ children }) => {
   const [structure, setStructure] = useState([]);
   const [path, setPath] = useState({ phase: 1, tab: 1, section: 1, question: 1 });
+  const [progress, setProgress] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('questionProgress')) || {};
+    } catch {
+      return {};
+    }
+  });
 
   useEffect(() => {
     getNavigationStructure().then(setStructure);
@@ -24,12 +31,20 @@ export const NavigationProvider = ({ children }) => {
     localStorage.setItem('lastLocation', toCode(path));
   }, [path, structure]);
 
+  useEffect(() => {
+    localStorage.setItem('questionProgress', JSON.stringify(progress));
+  }, [progress]);
+
   const navigateTo = (next) => {
     setPath(normalizePath(next, structure));
   };
 
+  const markVisited = (id) => {
+    setProgress((prev) => (prev[id] ? prev : { ...prev, [id]: true }));
+  };
+
   return (
-    <NavigationContext.Provider value={{ structure, path, navigateTo }}>
+    <NavigationContext.Provider value={{ structure, path, navigateTo, progress, markVisited }}>
       {children}
     </NavigationContext.Provider>
   );

--- a/changepreneurship-enhanced/src/lib/navigation.js
+++ b/changepreneurship-enhanced/src/lib/navigation.js
@@ -27,63 +27,133 @@ export function normalizePath(path, structure) {
   };
 }
 
-export function getNext(path, structure) {
+export function getNext(path, structure, level = 'question') {
   const { phase, tab, section, question } = normalizePath(path, structure);
   const phaseNode = structure.find((p) => p.code === phase);
   const tabNode = phaseNode.tabs.find((t) => t.code === tab);
   const sectionNode = tabNode.sections.find((s) => s.code === section);
+
+  if (level === 'phase') {
+    const pIndex = structure.findIndex((p) => p.code === phase);
+    if (pIndex < structure.length - 1) {
+      const nextPhase = structure[pIndex + 1];
+      const nextTab = nextPhase.tabs[0];
+      const nextSection = nextTab.sections[0];
+      const nextQuestion = nextSection.questions[0];
+      return {
+        phase: nextPhase.code,
+        tab: nextTab.code,
+        section: nextSection.code,
+        question: nextQuestion.code,
+      };
+    }
+    return { phase, tab, section, question };
+  }
+
+  if (level === 'tab') {
+    const tIndex = phaseNode.tabs.findIndex((t) => t.code === tab);
+    if (tIndex < phaseNode.tabs.length - 1) {
+      const nextTab = phaseNode.tabs[tIndex + 1];
+      const nextSection = nextTab.sections[0];
+      return {
+        phase,
+        tab: nextTab.code,
+        section: nextSection.code,
+        question: nextSection.questions[0].code,
+      };
+    }
+    return getNext({ phase, tab, section, question }, structure, 'phase');
+  }
+
+  if (level === 'section') {
+    const sIndex = tabNode.sections.findIndex((s) => s.code === section);
+    if (sIndex < tabNode.sections.length - 1) {
+      const nextSection = tabNode.sections[sIndex + 1];
+      return {
+        phase,
+        tab,
+        section: nextSection.code,
+        question: nextSection.questions[0].code,
+      };
+    }
+    return getNext({ phase, tab, section, question }, structure, 'tab');
+  }
+
   const qIndex = sectionNode.questions.findIndex((q) => q.code === question);
   if (qIndex < sectionNode.questions.length - 1) {
-    return { phase, tab, section, question: sectionNode.questions[qIndex + 1].code };
+    return {
+      phase,
+      tab,
+      section,
+      question: sectionNode.questions[qIndex + 1].code,
+    };
   }
-  const sIndex = tabNode.sections.findIndex((s) => s.code === section);
-  if (sIndex < tabNode.sections.length - 1) {
-    const nextSection = tabNode.sections[sIndex + 1];
-    return { phase, tab, section: nextSection.code, question: nextSection.questions[0].code };
-  }
-  const tIndex = phaseNode.tabs.findIndex((t) => t.code === tab);
-  if (tIndex < phaseNode.tabs.length - 1) {
-    const nextTab = phaseNode.tabs[tIndex + 1];
-    const nextSection = nextTab.sections[0];
-    return { phase, tab: nextTab.code, section: nextSection.code, question: nextSection.questions[0].code };
-  }
-  const pIndex = structure.findIndex((p) => p.code === phase);
-  if (pIndex < structure.length - 1) {
-    const nextPhase = structure[pIndex + 1];
-    const nextTab = nextPhase.tabs[0];
-    const nextSection = nextTab.sections[0];
-    return { phase: nextPhase.code, tab: nextTab.code, section: nextSection.code, question: nextSection.questions[0].code };
-  }
-  return { phase, tab, section, question };
+  return getNext({ phase, tab, section, question }, structure, 'section');
 }
 
-export function getPrev(path, structure) {
+export function getPrev(path, structure, level = 'question') {
   const { phase, tab, section, question } = normalizePath(path, structure);
   const phaseNode = structure.find((p) => p.code === phase);
   const tabNode = phaseNode.tabs.find((t) => t.code === tab);
   const sectionNode = tabNode.sections.find((s) => s.code === section);
+
+  if (level === 'phase') {
+    const pIndex = structure.findIndex((p) => p.code === phase);
+    if (pIndex > 0) {
+      const prevPhase = structure[pIndex - 1];
+      const prevTab = prevPhase.tabs[prevPhase.tabs.length - 1];
+      const prevSection = prevTab.sections[prevTab.sections.length - 1];
+      const prevQuestion =
+        prevSection.questions[prevSection.questions.length - 1];
+      return {
+        phase: prevPhase.code,
+        tab: prevTab.code,
+        section: prevSection.code,
+        question: prevQuestion.code,
+      };
+    }
+    return { phase, tab, section, question };
+  }
+
+  if (level === 'tab') {
+    const tIndex = phaseNode.tabs.findIndex((t) => t.code === tab);
+    if (tIndex > 0) {
+      const prevTab = phaseNode.tabs[tIndex - 1];
+      const prevSection = prevTab.sections[prevTab.sections.length - 1];
+      return {
+        phase,
+        tab: prevTab.code,
+        section: prevSection.code,
+        question: prevSection.questions[prevSection.questions.length - 1].code,
+      };
+    }
+    return getPrev({ phase, tab, section, question }, structure, 'phase');
+  }
+
+  if (level === 'section') {
+    const sIndex = tabNode.sections.findIndex((s) => s.code === section);
+    if (sIndex > 0) {
+      const prevSection = tabNode.sections[sIndex - 1];
+      return {
+        phase,
+        tab,
+        section: prevSection.code,
+        question:
+          prevSection.questions[prevSection.questions.length - 1].code,
+      };
+    }
+    return getPrev({ phase, tab, section, question }, structure, 'tab');
+  }
+
   const qIndex = sectionNode.questions.findIndex((q) => q.code === question);
   if (qIndex > 0) {
-    return { phase, tab, section, question: sectionNode.questions[qIndex - 1].code };
+    return {
+      phase,
+      tab,
+      section,
+      question: sectionNode.questions[qIndex - 1].code,
+    };
   }
-  const sIndex = tabNode.sections.findIndex((s) => s.code === section);
-  if (sIndex > 0) {
-    const prevSection = tabNode.sections[sIndex - 1];
-    return { phase, tab, section: prevSection.code, question: prevSection.questions[prevSection.questions.length - 1].code };
-  }
-  const tIndex = phaseNode.tabs.findIndex((t) => t.code === tab);
-  if (tIndex > 0) {
-    const prevTab = phaseNode.tabs[tIndex - 1];
-    const prevSection = prevTab.sections[prevTab.sections.length - 1];
-    return { phase, tab: prevTab.code, section: prevSection.code, question: prevSection.questions[prevSection.questions.length - 1].code };
-  }
-  const pIndex = structure.findIndex((p) => p.code === phase);
-  if (pIndex > 0) {
-    const prevPhase = structure[pIndex - 1];
-    const prevTab = prevPhase.tabs[prevPhase.tabs.length - 1];
-    const prevSection = prevTab.sections[prevTab.sections.length - 1];
-    return { phase: prevPhase.code, tab: prevTab.code, section: prevSection.code, question: prevSection.questions[prevSection.questions.length - 1].code };
-  }
-  return { phase, tab, section, question };
+  return getPrev({ phase, tab, section, question }, structure, 'section');
 }
 


### PR DESCRIPTION
## Summary
- add level-aware next/prev utilities for phases, tabs, sections, and questions
- persist last question visited and track question progress by id
- expose prev/next controls for every navigation tier with breadcrumb deep links

## Testing
- `pnpm exec eslint src/lib/navigation.js src/contexts/NavigationContext.jsx src/components/navigation/QuestionNavigator.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68c4309d457483218e3fa018dbd90b8f