### PR TITLE
feat: add normalized questionnaire scaffold

### DIFF
--- a/changepreneurship-enhanced/public/questionnaire.json
+++ b/changepreneurship-enhanced/public/questionnaire.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "phases": [
+    {
+      "id": "phase-1",
+      "title": "Phase 1",
+      "tabs": [
+        {
+          "id": "tab-1",
+          "title": "Business Model",
+          "sections": [
+            {
+              "id": "section-1",
+              "title": "Problem",
+              "questions": [
+                {
+                  "id": "question-1",
+                  "prompt": "Describe the problem you are solving.",
+                  "type": "textarea",
+                  "required": true
+                },
+                {
+                  "id": "question-2",
+                  "prompt": "Who experiences this problem?",
+                  "type": "text"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/changepreneurship-enhanced/src/App.jsx
+++ b/changepreneurship-enhanced/src/App.jsx
@@ -67,6 +67,7 @@ import SimpleAdaptiveDemo from "./components/SimpleAdaptiveDemo";
 import ProfileSettings from "./components/ProfileSettings";
 import AssessmentHistory from "./components/AssessmentHistory";
 import NavBar from "./components/NavBar";
+import PhasePage from "./pages/PhasePage.jsx";
 
 const AssessmentPage = () => {
   const { assessmentData, currentPhase, updatePhase } = useAssessment();
@@ -310,6 +311,10 @@ function App() {
                   <Route path="/simple-adaptive" element={<SimpleAdaptiveDemo />} />
                   <Route path="/profile" element={<ProfileSettings />} />
                   <Route path="/assessment-history" element={<AssessmentHistory />} />
+                  <Route
+                    path="/new/:phaseId/:tabId/:sectionId/:questionId"
+                    element={<PhasePage />}
+                  />
                   <Route
                     path="/phase/:phase/tab/:tab/section/:section/question/:question"
                     element={<QuestionNavigator />}

--- a/changepreneurship-enhanced/src/api.js
+++ b/changepreneurship-enhanced/src/api.js
@@ -1,0 +1,26 @@
+import { validateQuestionnaire } from "./lib/schema.js";
+
+let questionnaireCache = null;
+
+export async function fetchQuestionnaire() {
+  if (questionnaireCache) return questionnaireCache;
+  const res = await fetch("/questionnaire.json");
+  const data = await res.json();
+  questionnaireCache = validateQuestionnaire(data);
+  return questionnaireCache;
+}
+
+export async function fetchPhase(phaseId) {
+  const q = await fetchQuestionnaire();
+  return q.phases.find((p) => p.id === phaseId);
+}
+
+export async function fetchTab(phaseId, tabId) {
+  const phase = await fetchPhase(phaseId);
+  return phase?.tabs?.find((t) => t.id === tabId);
+}
+
+export async function fetchSection(phaseId, tabId, sectionId) {
+  const tab = await fetchTab(phaseId, tabId);
+  return tab?.sections?.find((s) => s.id === sectionId);
+}

--- a/changepreneurship-enhanced/src/components/QuestionView.jsx
+++ b/changepreneurship-enhanced/src/components/QuestionView.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from "react";
+
+export default function QuestionView({ question }) {
+  const [answer, setAnswer] = useState("");
+  const [status, setStatus] = useState("saved");
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setStatus("saving");
+      fetch(`/api/answers/${question.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ answer })
+      }).finally(() => setStatus("saved"));
+    }, 600);
+    return () => clearTimeout(handle);
+  }, [answer, question.id]);
+
+  const Input = question.type === "textarea" ? "textarea" : "input";
+
+  return (
+    <div>
+      <label className="block mb-1">{question.prompt}</label>
+      <Input
+        className="w-full border rounded p-1"
+        value={answer}
+        onChange={(e) => setAnswer(e.target.value)}
+      />
+      <small className="text-xs">
+        {status === "saving" ? "Saving…" : "Saved"}
+      </small>
+    </div>
+  );
+}

--- a/changepreneurship-enhanced/src/components/SectionView.jsx
+++ b/changepreneurship-enhanced/src/components/SectionView.jsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import QuestionView from "./QuestionView.jsx";
+import { fetchSection } from "../api.js";
+
+const ITEM_HEIGHT = 80;
+
+export default function SectionView({ phaseId, tabId, sectionId }) {
+  const [section, setSection] = useState(null);
+  const [scrollTop, setScrollTop] = useState(0);
+
+  useEffect(() => {
+    fetchSection(phaseId, tabId, sectionId).then(setSection);
+  }, [phaseId, tabId, sectionId]);
+
+  if (!section) return <p>Loading section...</p>;
+
+  const { questions } = section;
+  const onScroll = (e) => setScrollTop(e.currentTarget.scrollTop);
+  const startIndex = Math.max(0, Math.floor(scrollTop / ITEM_HEIGHT) - 5);
+  const endIndex = Math.min(
+    questions.length,
+    Math.ceil((scrollTop + 400) / ITEM_HEIGHT) + 5
+  );
+  const offsetY = startIndex * ITEM_HEIGHT;
+  const visible = questions.slice(startIndex, endIndex);
+
+  return (
+    <div
+      style={{ height: 400, overflow: "auto" }}
+      onScroll={onScroll}
+      className="border"
+    >
+      <div style={{ height: questions.length * ITEM_HEIGHT, position: "relative" }}>
+        <div style={{ transform: `translateY(${offsetY}px)` }}>
+          {visible.map((q) => (
+            <div key={q.id} style={{ height: ITEM_HEIGHT }} className="p-4 border-b">
+              <QuestionView question={q} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/changepreneurship-enhanced/src/lib/importExport.js
+++ b/changepreneurship-enhanced/src/lib/importExport.js
@@ -1,0 +1,13 @@
+import { validateQuestionnaire } from "./schema.js";
+
+export async function importJson(file) {
+  const text = await file.text();
+  const data = JSON.parse(text);
+  return validateQuestionnaire(data);
+}
+
+export function exportJson(data) {
+  return new Blob([JSON.stringify(data, null, 2)], {
+    type: "application/json"
+  });
+}

--- a/changepreneurship-enhanced/src/lib/schema.js
+++ b/changepreneurship-enhanced/src/lib/schema.js
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+const QuestionSchema = z.object({
+  id: z.string(),
+  prompt: z.string(),
+  type: z.enum(["text", "textarea", "select"]),
+  required: z.boolean().optional()
+});
+
+const SectionSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  questions: z.array(QuestionSchema)
+});
+
+const TabSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  sections: z.array(SectionSchema).optional()
+});
+
+const PhaseSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  tabs: z.array(TabSchema).optional(),
+  version: z.number().optional()
+});
+
+export const QuestionnaireSchema = z.object({
+  version: z.number(),
+  phases: z.array(PhaseSchema)
+});
+
+export function validateQuestionnaire(data) {
+  return QuestionnaireSchema.parse(data);
+}

--- a/changepreneurship-enhanced/src/pages/PhasePage.jsx
+++ b/changepreneurship-enhanced/src/pages/PhasePage.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from "react";
+import { useParams, Navigate } from "react-router-dom";
+import { fetchPhase, fetchTab } from "../api.js";
+import SectionView from "../components/SectionView.jsx";
+
+export default function PhasePage() {
+  const { phaseId, tabId, sectionId } = useParams();
+  const [phase, setPhase] = useState(null);
+  const [tab, setTab] = useState(null);
+
+  useEffect(() => {
+    fetchPhase(phaseId).then(setPhase);
+  }, [phaseId]);
+
+  useEffect(() => {
+    fetchTab(phaseId, tabId).then(setTab);
+  }, [phaseId, tabId]);
+
+  if (!phase || !tab) return <p>Loading...</p>;
+  if (!phase.tabs) return <Navigate to="/" replace />;
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">{phase.title} / {tab.title}</h1>
+      <SectionView phaseId={phaseId} tabId={tabId} sectionId={sectionId} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add normalized questionnaire data spec and Zod validator
- build API helpers and demo PhasePage with virtualized SectionView and debounced autosave
- expose new `/new/:phaseId/:tabId/:sectionId/:questionId` route

## Testing
- `pnpm lint` *(fails: "Command failed with exit code 1" due to existing lint errors)*
- `pnpm exec eslint src/api.js src/components/QuestionView.jsx src/components/SectionView.jsx src/lib/importExport.js src/lib/schema.js src/pages/PhasePage.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68c43eda4418832189b594932823c88d