### PR TITLE
Avoid auto-creating entrepreneur profiles on fetch

### DIFF
--- a/changepreneurship-backend/src/routes/auth.py
+++ b/changepreneurship-backend/src/routes/auth.py
@@ -178,9 +178,7 @@ def get_profile():
 
         profile = EntrepreneurProfile.query.filter_by(user_id=user.id).first()
         if not profile:
-            profile = EntrepreneurProfile(user_id=user.id)
-            db.session.add(profile)
-            db.session.commit()
+            return jsonify({'error': 'Profile not found'}), 404
 
         return jsonify({'user': user.to_dict(), 'profile': profile.to_dict()}), 200
 

--- a/changepreneurship-enhanced/src/services/api.js
+++ b/changepreneurship-enhanced/src/services/api.js
@@ -188,6 +188,11 @@ class ApiService {
       method: "GET",
       headers: this.getHeaders(),
     });
+
+    if (res.status === 404) {
+      return { success: true, data: { user: null, profile: null } };
+    }
+
     return this.handleResponse(res);
   }
 


### PR DESCRIPTION
## Summary
- Stop creating entrepreneur profiles on GET /auth/profile
- Return 404 when profile is missing and handle this case on the frontend

## Testing
- `pytest`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c458a1d4988321b6a234c9b5c37c09