### PR TITLE
Refactor assessment API hook to use success/data/error responses

### DIFF
--- a/changepreneurship-enhanced/src/hooks/useAssessmentAPI.js
+++ b/changepreneurship-enhanced/src/hooks/useAssessmentAPI.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 
 export const useAssessmentAPI = () => {
@@ -36,11 +36,11 @@ export const useAssessmentAPI = () => {
       })
 
       let assessmentId
-      if (startResponse.ok) {
-        const startData = await startResponse.json()
+      if (startResponse.success) {
+        const startData = startResponse.data
         assessmentId = startData.assessment_id
       } else {
-        throw new Error('Failed to start assessment phase')
+        throw new Error(startResponse.error)
       }
 
       // Save responses if provided
@@ -92,11 +92,10 @@ export const useAssessmentAPI = () => {
       setError(null)
 
       const response = await apiCall('/assessment/phases')
-      if (response.ok) {
-        const data = await response.json()
-        return data
+      if (response.success) {
+        return response.data
       } else {
-        throw new Error('Failed to load assessment data')
+        throw new Error(response.error)
       }
     } catch (err) {
       setError(err.message)
@@ -131,10 +130,10 @@ export const useAssessmentAPI = () => {
         body: JSON.stringify(profileData)
       })
 
-      if (response.ok) {
-        return { success: true }
+      if (response.success) {
+        return response.data
       } else {
-        throw new Error('Failed to save profile')
+        throw new Error(response.error)
       }
     } catch (err) {
       setError(err.message)
@@ -158,11 +157,11 @@ export const useAssessmentAPI = () => {
 
       // First get the assessment ID for this phase
       const phasesResponse = await apiCall('/assessment/phases')
-      if (!phasesResponse.ok) {
-        throw new Error('Failed to get assessment phases')
+      if (!phasesResponse.success) {
+        throw new Error(phasesResponse.error)
       }
 
-      const phasesData = await phasesResponse.json()
+      const phasesData = phasesResponse.data
       const assessment = phasesData.assessments.find(a => a.phase_id === phaseId)
       
       if (!assessment) {
@@ -170,11 +169,11 @@ export const useAssessmentAPI = () => {
       }
 
       const responsesResponse = await apiCall(`/assessment/${assessment.id}/responses`)
-      if (responsesResponse.ok) {
-        const responsesData = await responsesResponse.json()
+      if (responsesResponse.success) {
+        const responsesData = responsesResponse.data
         return responsesData.responses || {}
       } else {
-        throw new Error('Failed to get assessment responses')
+        throw new Error(responsesResponse.error)
       }
     } catch (err) {
       setError(err.message)


### PR DESCRIPTION
## Summary
- handle assessment API responses via `response.success` and `response.data`
- surface API errors through `response.error`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 75 problems, 54 errors, 21 warnings)*
- `npx eslint src/hooks/useAssessmentAPI.js`


------
https://chatgpt.com/codex/tasks/task_e_68c4c4bdf6a08321bb22c8e2d666a482