### PR TITLE
Handle LinkedIn and resume uploads for assessment optimization

### DIFF
--- a/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx
@@ -271,17 +271,18 @@ const SelfDiscoveryAssessment = () => {
   };
 
   // Handle data import optimization using imported data
-  const handleOptimization = async (sources = []) => {
+  const handleOptimization = async (sources = {}) => {
     setShowDataImport(false);
 
     const importedData = {};
     const successful = [];
 
-    for (const source of sources) {
+    for (const [source, file] of Object.entries(sources)) {
       try {
         let result;
-        if (source === "linkedin") result = await api.connectLinkedIn();
-        if (source === "resume") result = await api.uploadResume();
+        if (source === "linkedin" && file)
+          result = await api.uploadLinkedInData(file);
+        if (source === "resume" && file) result = await api.uploadResume(file);
         if (source === "financial")
           result = await api.connectFinancialAccounts();
 

--- a/changepreneurship-enhanced/src/services/__tests__/api.test.js
+++ b/changepreneurship-enhanced/src/services/__tests__/api.test.js
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import api from '../api.js';
 
 assert.ok(api);
-assert.equal(typeof api.connectLinkedIn, 'function');
+assert.equal(typeof api.uploadLinkedInData, 'function');
 assert.equal(typeof api.uploadResume, 'function');
 assert.equal(typeof api.connectFinancialAccounts, 'function');
 console.log('ApiService imported successfully');

--- a/changepreneurship-enhanced/src/services/api.js
+++ b/changepreneurship-enhanced/src/services/api.js
@@ -405,14 +405,26 @@ class ApiService {
   // ==================== DATA IMPORT METHODS ====================
 
   /**
-   * Connect and import LinkedIn data
+   * Upload and parse LinkedIn profile PDF
+   * @param {File} file - LinkedIn profile file uploaded by user
    * @returns {Promise<Object>} Parsed LinkedIn data
    */
-  async connectLinkedIn(payload = {}) {
-    return this.request('/data/import/linkedin', {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    });
+  async uploadLinkedInData(file) {
+    try {
+      const formData = new FormData();
+      if (file) formData.append('file', file);
+      const headers = this.sessionToken
+        ? { Authorization: `Bearer ${this.sessionToken}` }
+        : {};
+      const res = await fetch(`${API_BASE_URL}/data/import/linkedin`, {
+        method: 'POST',
+        headers,
+        body: formData,
+      });
+      return this.handleResponse(res);
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary
- add hidden PDF upload inputs for LinkedIn and resume
- transmit selected files with chosen sources for optimization
- replace LinkedIn API call with file upload flow and adjust tests

## Testing
- `pnpm lint` (fails: Unexpected lexical declaration in case block)
- `pnpm test` (no output)
- `node src/services/__tests__/api.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6b8bcbb688321a82c7873c04acbe9