### PR TITLE
Handle DataImport banner dismissal when skipping optimization

### DIFF
--- a/changepreneurship-enhanced/src/components/adaptive/DataImportBanner.jsx
+++ b/changepreneurship-enhanced/src/components/adaptive/DataImportBanner.jsx
@@ -118,7 +118,11 @@ export default function DataImportBanner({ onOptimize, onDismiss }) {
           >
             Start Optimized Assessment
           </Button>
-          <Button className="flex-1" variant="secondary">
+          <Button
+            className="flex-1"
+            variant="secondary"
+            onClick={onDismiss}
+          >
             Continue Without Optimization
           </Button>
         </div>


### PR DESCRIPTION
## Summary
- wire "Continue Without Optimization" button to call the provided dismiss handler
- ensure SelfDiscoveryAssessment flows after the banner is removed

## Testing
- `pnpm lint` *(fails: 74 problems, 53 errors, 21 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f8e0fb5c8321a82bb91ec4333d57