### PR TITLE
Add next phase navigation for assessments

### DIFF
--- a/changepreneurship-enhanced/src/components/assessment/IdeaDiscoveryAssessment.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/IdeaDiscoveryAssessment.jsx
@@ -29,11 +29,12 @@ import {
 import { useAssessment } from '../../contexts/AssessmentContext'
 
 const IdeaDiscoveryAssessment = () => {
-  const { 
-    assessmentData, 
-    updateResponse, 
-    updateProgress, 
-    completePhase 
+  const {
+    assessmentData,
+    updateResponse,
+    updateProgress,
+    completePhase,
+    updatePhase
   } = useAssessment()
   
   const [currentSection, setCurrentSection] = useState('core-alignment')
@@ -216,21 +217,30 @@ const IdeaDiscoveryAssessment = () => {
 
       {/* Navigation Buttons */}
       <div className="flex justify-between">
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={previousSection}
           disabled={currentSectionIndex === 0}
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
           Previous
         </Button>
-        <Button 
-          onClick={nextSection}
-          disabled={currentSectionIndex === sections.length - 1}
-        >
-          Next
-          <ArrowRight className="h-4 w-4 ml-2" />
-        </Button>
+        {currentSectionIndex === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase("idea-discovery");
+              updatePhase("market-research");
+            }}
+          >
+            Next Phase
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        ) : (
+          <Button onClick={nextSection}>
+            Next
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx
@@ -171,6 +171,7 @@ const SelfDiscoveryAssessment = () => {
     updateResponse,
     updateProgress,
     completePhase,
+    updatePhase,
     calculateArchetype,
   } = useAssessment();
 
@@ -463,13 +464,22 @@ const SelfDiscoveryAssessment = () => {
           <ArrowLeft className="h-4 w-4 mr-2" />
           Previous
         </Button>
-        <Button
-          onClick={nextSection}
-          disabled={currentSectionIndex === sections.length - 1}
-        >
-          Next
-          <ArrowRight className="h-4 w-4 ml-2" />
-        </Button>
+        {currentSectionIndex === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase("self-discovery");
+              updatePhase("idea-discovery");
+            }}
+          >
+            Next Phase
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        ) : (
+          <Button onClick={nextSection}>
+            Next
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- integrate `updatePhase` into self- and idea-discovery assessments
- show **Next Phase** button on final sections to move between phases

## Testing
- `pnpm lint` *(fails: no-case-declarations, no-unused-vars, etc.)*
- `pnpm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c700255e74832197bf3dbf65e1d49d