### PR TITLE
Add phase transitions for assessment components

### DIFF
--- a/changepreneurship-enhanced/src/components/assessment/BusinessDevelopmentDecisionMaking.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/BusinessDevelopmentDecisionMaking.jsx
@@ -39,7 +39,7 @@ import {
 import { useAssessment } from "../../contexts/AssessmentContext";
 
 const BusinessDevelopmentDecisionMaking = () => {
-  const { assessmentData, updateAssessmentData } = useAssessment();
+  const { assessmentData, updateAssessmentData, completePhase, updatePhase } = useAssessment();
   const [currentSection, setCurrentSection] = useState(0);
   const [sectionData, setSectionData] = useState({
     strategicDecisionMatrix: {
@@ -1077,14 +1077,24 @@ const BusinessDevelopmentDecisionMaking = () => {
         >
           Previous Section
         </Button>
-        <Button
-          onClick={() =>
-            setCurrentSection(Math.min(sections.length - 1, currentSection + 1))
-          }
-          disabled={currentSection === sections.length - 1}
-        >
-          Next Section
-        </Button>
+        {currentSection === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase('business-development')
+              updatePhase('business-prototype-testing')
+            }}
+          >
+            Next Phase
+          </Button>
+        ) : (
+          <Button
+            onClick={() =>
+              setCurrentSection(Math.min(sections.length - 1, currentSection + 1))
+            }
+          >
+            Next Section
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/changepreneurship-enhanced/src/components/assessment/BusinessPillarsPlanning.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/BusinessPillarsPlanning.jsx
@@ -41,11 +41,12 @@ import {
 import { useAssessment } from '../../contexts/AssessmentContext'
 
 const BusinessPillarsPlanning = () => {
-  const { 
-    assessmentData, 
-    updateResponse, 
-    updateProgress, 
-    completePhase 
+  const {
+    assessmentData,
+    updateResponse,
+    updateProgress,
+    completePhase,
+    updatePhase
   } = useAssessment()
   
   const [currentSection, setCurrentSection] = useState('customer-segmentation')
@@ -242,21 +243,30 @@ const BusinessPillarsPlanning = () => {
 
       {/* Navigation Buttons */}
       <div className="flex justify-between">
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={previousSection}
           disabled={currentSectionIndex === 0}
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
           Previous
         </Button>
-        <Button 
-          onClick={nextSection}
-          disabled={currentSectionIndex === sections.length - 1}
-        >
-          Next
-          <ArrowRight className="h-4 w-4 ml-2" />
-        </Button>
+        {currentSectionIndex === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase('business-pillars')
+              updatePhase('product-concept-testing')
+            }}
+          >
+            Next Phase
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        ) : (
+          <Button onClick={nextSection}>
+            Next
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/changepreneurship-enhanced/src/components/assessment/BusinessPrototypeTesting.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/BusinessPrototypeTesting.jsx
@@ -48,7 +48,7 @@ import {
 import { useAssessment } from "../../contexts/AssessmentContext";
 
 const BusinessPrototypeTesting = () => {
-  const { assessmentData, updateAssessmentData } = useAssessment();
+  const { assessmentData, updateAssessmentData, completePhase, updatePhase } = useAssessment();
   const [currentSection, setCurrentSection] = useState(0);
   const [sectionData, setSectionData] = useState({
     customerValueProposition: {
@@ -2289,14 +2289,24 @@ const BusinessPrototypeTesting = () => {
         >
           Previous Section
         </Button>
-        <Button
-          onClick={() =>
-            setCurrentSection(Math.min(sections.length - 1, currentSection + 1))
-          }
-          disabled={currentSection === sections.length - 1}
-        >
-          Next Section
-        </Button>
+        {currentSection === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase('business-prototype-testing')
+              updatePhase(null)
+            }}
+          >
+            Next Phase
+          </Button>
+        ) : (
+          <Button
+            onClick={() =>
+              setCurrentSection(Math.min(sections.length - 1, currentSection + 1))
+            }
+          >
+            Next Section
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/changepreneurship-enhanced/src/components/assessment/MarketResearchTools.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/MarketResearchTools.jsx
@@ -33,11 +33,12 @@ import {
 import { useAssessment } from '../../contexts/AssessmentContext'
 
 const MarketResearchTools = () => {
-  const { 
-    assessmentData, 
-    updateResponse, 
-    updateProgress, 
-    completePhase 
+  const {
+    assessmentData,
+    updateResponse,
+    updateProgress,
+    completePhase,
+    updatePhase
   } = useAssessment()
   
   const [currentSection, setCurrentSection] = useState('competitive-analysis')
@@ -225,21 +226,30 @@ const MarketResearchTools = () => {
 
       {/* Navigation Buttons */}
       <div className="flex justify-between">
-        <Button 
-          variant="outline" 
+        <Button
+          variant="outline"
           onClick={previousSection}
           disabled={currentSectionIndex === 0}
         >
           <ArrowLeft className="h-4 w-4 mr-2" />
           Previous
         </Button>
-        <Button 
-          onClick={nextSection}
-          disabled={currentSectionIndex === sections.length - 1}
-        >
-          Next
-          <ArrowRight className="h-4 w-4 ml-2" />
-        </Button>
+        {currentSectionIndex === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase('market-research')
+              updatePhase('business-pillars')
+            }}
+          >
+            Next Phase
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        ) : (
+          <Button onClick={nextSection}>
+            Next
+            <ArrowRight className="h-4 w-4 ml-2" />
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/changepreneurship-enhanced/src/components/assessment/ProductConceptTesting.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/ProductConceptTesting.jsx
@@ -33,7 +33,7 @@ import {
 import { useAssessment } from "../../contexts/AssessmentContext";
 
 const ProductConceptTesting = () => {
-  const { assessmentData, updateAssessmentData } = useAssessment();
+  const { assessmentData, updateAssessmentData, completePhase, updatePhase } = useAssessment();
   const [currentSection, setCurrentSection] = useState(0);
 
   const [sectionData, setSectionData] = useState({
@@ -878,14 +878,24 @@ const ProductConceptTesting = () => {
         >
           Previous Section
         </Button>
-        <Button
-          onClick={() =>
-            setCurrentSection(Math.min(sections.length - 1, currentSection + 1))
-          }
-          disabled={currentSection === sections.length - 1}
-        >
-          Next Section
-        </Button>
+        {currentSection === sections.length - 1 ? (
+          <Button
+            onClick={() => {
+              completePhase('product-concept-testing')
+              updatePhase('business-development')
+            }}
+          >
+            Next Phase
+          </Button>
+        ) : (
+          <Button
+            onClick={() =>
+              setCurrentSection(Math.min(sections.length - 1, currentSection + 1))
+            }
+          >
+            Next Section
+          </Button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Import updatePhase in assessment components and add phase-completion logic
- Swap single Next buttons for Next Phase logic at end of each assessment

## Testing
- `pnpm lint` *(fails: 73 problems including unused vars and no-undef)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d54183d48321a412550180ef1731