### PR TITLE
Use underscore assessment phase identifiers in enhanced app

### DIFF
--- a/changepreneurship-enhanced/src/App.jsx
+++ b/changepreneurship-enhanced/src/App.jsx
@@ -75,13 +75,13 @@ const AssessmentPage = () => {
       const phaseNumber = parseInt(phaseParam);
       if (phaseNumber >= 1 && phaseNumber <= 7) {
         const phaseIds = [
-          "self-discovery",
-          "idea-discovery",
-          "market-research",
-          "business-pillars",
-          "product-concept-testing",
-          "business-development",
-          "business-prototype-testing",
+          "self_discovery",
+          "idea_discovery",
+          "market_research",
+          "business_pillars",
+          "product_concept_testing",
+          "business_development",
+          "business_prototype_testing",
         ];
         const phaseId = phaseIds[phaseNumber - 1];
         setSelectedPhase(phaseId);
@@ -92,7 +92,7 @@ const AssessmentPage = () => {
 
   const phases = [
     {
-      id: "self-discovery",
+      id: "self_discovery",
       title: "Self Discovery",
       description:
         "Understand your entrepreneurial personality and motivations",
@@ -103,7 +103,7 @@ const AssessmentPage = () => {
       component: SelfDiscoveryAssessment,
     },
     {
-      id: "idea-discovery",
+      id: "idea_discovery",
       title: "Idea Discovery",
       description: "Transform insights into concrete business opportunities",
       icon: Lightbulb,
@@ -113,7 +113,7 @@ const AssessmentPage = () => {
       component: IdeaDiscoveryAssessment,
     },
     {
-      id: "market-research",
+      id: "market_research",
       title: "Market Research",
       description: "Validate assumptions and understand competitive dynamics",
       icon: Search,
@@ -123,7 +123,7 @@ const AssessmentPage = () => {
       component: MarketResearchTools,
     },
     {
-      id: "business-pillars",
+      id: "business_pillars",
       title: "Business Pillars",
       description: "Define foundational elements for strategic planning",
       icon: Building,
@@ -133,7 +133,7 @@ const AssessmentPage = () => {
       component: BusinessPillarsPlanning,
     },
     {
-      id: "product-concept-testing",
+      id: "product_concept_testing",
       title: "Product Concept Testing",
       description: "Validate product concepts with real customer feedback",
       icon: TestTube,
@@ -143,7 +143,7 @@ const AssessmentPage = () => {
       component: ProductConceptTesting,
     },
     {
-      id: "business-development",
+      id: "business_development",
       title: "Business Development",
       description: "Strategic decision-making and resource optimization",
       icon: Settings,
@@ -153,7 +153,7 @@ const AssessmentPage = () => {
       component: BusinessDevelopmentDecisionMaking,
     },
     {
-      id: "business-prototype-testing",
+      id: "business_prototype_testing",
       title: "Business Prototype Testing",
       description:
         "Complete business model validation in real market conditions",

--- a/changepreneurship-enhanced/src/components/AssessmentHistory.jsx
+++ b/changepreneurship-enhanced/src/components/AssessmentHistory.jsx
@@ -9,13 +9,13 @@ import {
 import { Progress } from "@/components/ui/progress.jsx";
 
 const phases = [
-  { id: "self-discovery", name: "Self Discovery" },
-  { id: "idea-discovery", name: "Idea Discovery" },
-  { id: "market-research", name: "Market Research" },
-  { id: "business-pillars", name: "Business Pillars" },
-  { id: "product-concept-testing", name: "Product Concept Testing" },
-  { id: "business-development", name: "Business Development" },
-  { id: "business-prototype-testing", name: "Business Prototype Testing" },
+  { id: "self_discovery", name: "Self Discovery" },
+  { id: "idea_discovery", name: "Idea Discovery" },
+  { id: "market_research", name: "Market Research" },
+  { id: "business_pillars", name: "Business Pillars" },
+  { id: "product_concept_testing", name: "Product Concept Testing" },
+  { id: "business_development", name: "Business Development" },
+  { id: "business_prototype_testing", name: "Business Prototype Testing" },
 ];
 
 const AssessmentHistory = () => {

--- a/changepreneurship-enhanced/src/components/ProgressTracker.jsx
+++ b/changepreneurship-enhanced/src/components/ProgressTracker.jsx
@@ -32,7 +32,7 @@ const ProgressTracker = ({
 }) => {
   const phases = [
     {
-      id: "self-discovery",
+      id: "self_discovery",
       title: "Self Discovery",
       description: "Core motivation, values, and vision",
       icon: Heart,
@@ -47,7 +47,7 @@ const ProgressTracker = ({
       ],
     },
     {
-      id: "idea-discovery",
+      id: "idea_discovery",
       title: "Idea Discovery",
       description: "Business ideas and opportunities",
       icon: Lightbulb,
@@ -61,7 +61,7 @@ const ProgressTracker = ({
       ],
     },
     {
-      id: "market-research",
+      id: "market_research",
       title: "Market Research",
       description: "Industry analysis and validation",
       icon: Target,
@@ -73,7 +73,7 @@ const ProgressTracker = ({
       ],
     },
     {
-      id: "business-pillars",
+      id: "business_pillars",
       title: "Business Pillars",
       description: "Foundation and strategy planning",
       icon: Star,
@@ -94,7 +94,7 @@ const ProgressTracker = ({
       sections: ["concept-testing", "prototype-validation", "user-feedback"],
     },
     {
-      id: "business-development",
+      id: "business_development",
       title: "Business Development",
       description: "Growth and scaling strategies",
       icon: TrendingUp,

--- a/changepreneurship-enhanced/src/components/adaptive/PersonalizedAssessmentPath.jsx
+++ b/changepreneurship-enhanced/src/components/adaptive/PersonalizedAssessmentPath.jsx
@@ -43,7 +43,7 @@ export default function PersonalizedAssessmentPath() {
   // Assessment phases with adaptive data
   const phases = [
     {
-      id: 'self-discovery',
+      id: 'self_discovery',
       name: 'Self Discovery',
       description: 'Understanding your entrepreneurial personality and motivations',
       icon: Users,
@@ -51,7 +51,7 @@ export default function PersonalizedAssessmentPath() {
       estimatedTime: '60-90 min'
     },
     {
-      id: 'idea-discovery',
+      id: 'idea_discovery',
       name: 'Idea Discovery',
       description: 'Identifying and validating business opportunities',
       icon: Lightbulb,
@@ -59,7 +59,7 @@ export default function PersonalizedAssessmentPath() {
       estimatedTime: '90-120 min'
     },
     {
-      id: 'market-research',
+      id: 'market_research',
       name: 'Market Research',
       description: 'Analyzing market conditions and competitive landscape',
       icon: BarChart3,
@@ -67,7 +67,7 @@ export default function PersonalizedAssessmentPath() {
       estimatedTime: '2-3 weeks'
     },
     {
-      id: 'business-pillars',
+      id: 'business_pillars',
       name: 'Business Pillars',
       description: 'Building comprehensive business foundation',
       icon: Target,
@@ -75,7 +75,7 @@ export default function PersonalizedAssessmentPath() {
       estimatedTime: '1-2 weeks'
     },
     {
-      id: 'product-concept-testing',
+      id: 'product_concept_testing',
       name: 'Product Concept Testing',
       description: 'Validating product concepts with target market',
       icon: Star,
@@ -83,7 +83,7 @@ export default function PersonalizedAssessmentPath() {
       estimatedTime: '1-2 weeks'
     },
     {
-      id: 'business-development',
+      id: 'business_development',
       name: 'Business Development',
       description: 'Strategic business development and decision making',
       icon: TrendingUp,
@@ -91,7 +91,7 @@ export default function PersonalizedAssessmentPath() {
       estimatedTime: '2-3 weeks'
     },
     {
-      id: 'business-prototype-testing',
+      id: 'business_prototype_testing',
       name: 'Business Prototype Testing',
       description: 'Testing business prototypes and market readiness',
       icon: Award,

--- a/changepreneurship-enhanced/src/components/adaptive/QuestionOptimizationDemo.jsx
+++ b/changepreneurship-enhanced/src/components/adaptive/QuestionOptimizationDemo.jsx
@@ -365,7 +365,7 @@ export default function QuestionOptimizationDemo() {
                         { value: 'risk_averse', label: 'Risk Averse' }
                       ]
                     }}
-                    phase="self-discovery"
+                    phase="self_discovery"
                     showAdaptiveFeatures={true}
                   />
                 </div>
@@ -380,7 +380,7 @@ export default function QuestionOptimizationDemo() {
                       text: 'What is your industry experience level?',
                       type: 'pre_populated'
                     }}
-                    phase="self-discovery"
+                    phase="self_discovery"
                     showAdaptiveFeatures={true}
                   />
                 </div>

--- a/changepreneurship-enhanced/src/components/adaptive/UserProfileDetection.jsx
+++ b/changepreneurship-enhanced/src/components/adaptive/UserProfileDetection.jsx
@@ -77,7 +77,7 @@ export default function UserProfileDetection() {
   // Auto-trigger profile detection when enough responses
   useEffect(() => {
     if (responseCount >= 5 && !isProfileDetected()) {
-      processAdaptiveLogic('self-discovery')
+      processAdaptiveLogic('self_discovery')
     }
   }, [responseCount, isProfileDetected, processAdaptiveLogic])
 

--- a/changepreneurship-enhanced/src/components/assessment/BusinessDevelopmentDecisionMaking.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/BusinessDevelopmentDecisionMaking.jsx
@@ -228,7 +228,7 @@ const BusinessDevelopmentDecisionMaking = () => {
 
   // Load existing data
   useEffect(() => {
-    const existing = assessmentData["business-development"] || {};
+    const existing = assessmentData["business_development"] || {};
     if (Object.keys(existing).length > 0) {
       setSectionData((prev) => ({ ...prev, ...existing }));
     }
@@ -240,7 +240,7 @@ const BusinessDevelopmentDecisionMaking = () => {
   useEffect(() => {
     const serialized = JSON.stringify(sectionData);
     if (serialized !== lastSavedRef.current) {
-      updateAssessmentData("business-development", sectionData);
+      updateAssessmentData("business_development", sectionData);
       lastSavedRef.current = serialized;
     }
   }, [sectionData, updateAssessmentData]);
@@ -1080,8 +1080,8 @@ const BusinessDevelopmentDecisionMaking = () => {
         {currentSection === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase('business-development')
-              updatePhase('business-prototype-testing')
+              completePhase('business_development')
+              updatePhase('business_prototype_testing')
             }}
           >
             Next Phase

--- a/changepreneurship-enhanced/src/components/assessment/BusinessPillarsPlanning.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/BusinessPillarsPlanning.jsx
@@ -52,7 +52,7 @@ const BusinessPillarsPlanning = () => {
   const [currentSection, setCurrentSection] = useState('customer-segmentation')
   const [sectionProgress, setSectionProgress] = useState({})
   
-  const businessPillarsData = assessmentData['business-pillars'] || {}
+  const businessPillarsData = assessmentData['business_pillars'] || {}
   const responses = businessPillarsData.responses || {}
 
   // Assessment sections configuration
@@ -146,16 +146,16 @@ const BusinessPillarsPlanning = () => {
     
     // Update overall progress
     const overallProgress = calculateOverallProgress()
-    updateProgress('business-pillars', overallProgress)
+    updateProgress('business_pillars', overallProgress)
     
     // Complete phase if all sections are done
     if (overallProgress >= 100 && !businessPillarsData.completed) {
-      completePhase('business-pillars')
+      completePhase('business_pillars')
     }
   }, [responses])
 
   const handleResponse = (questionId, answer) => {
-    updateResponse('business-pillars', questionId, answer, currentSection)
+    updateResponse('business_pillars', questionId, answer, currentSection)
   }
 
   const nextSection = () => {
@@ -254,8 +254,8 @@ const BusinessPillarsPlanning = () => {
         {currentSectionIndex === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase('business-pillars')
-              updatePhase('product-concept-testing')
+              completePhase('business_pillars')
+              updatePhase('product_concept_testing')
             }}
           >
             Next Phase

--- a/changepreneurship-enhanced/src/components/assessment/BusinessPrototypeTesting.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/BusinessPrototypeTesting.jsx
@@ -292,7 +292,7 @@ const BusinessPrototypeTesting = () => {
 
   // Load existing data
   useEffect(() => {
-    const existingData = assessmentData["business-prototype-testing"] || {};
+    const existingData = assessmentData["business_prototype_testing"] || {};
     if (Object.keys(existingData).length > 0) {
       setSectionData({ ...sectionData, ...existingData });
     }
@@ -300,7 +300,7 @@ const BusinessPrototypeTesting = () => {
 
   // Save data when it changes
   useEffect(() => {
-    updateAssessmentData("business-prototype-testing", sectionData);
+    updateAssessmentData("business_prototype_testing", sectionData);
   }, [sectionData]);
 
   // Calculate completion percentage
@@ -2292,7 +2292,7 @@ const BusinessPrototypeTesting = () => {
         {currentSection === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase('business-prototype-testing')
+              completePhase('business_prototype_testing')
               updatePhase(null)
             }}
           >

--- a/changepreneurship-enhanced/src/components/assessment/IdeaDiscoveryAssessment.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/IdeaDiscoveryAssessment.jsx
@@ -40,7 +40,7 @@ const IdeaDiscoveryAssessment = () => {
   const [currentSection, setCurrentSection] = useState('core-alignment')
   const [sectionProgress, setSectionProgress] = useState({})
   
-  const ideaDiscoveryData = assessmentData['idea-discovery'] || {}
+  const ideaDiscoveryData = assessmentData['idea_discovery'] || {}
   const responses = ideaDiscoveryData.responses || {}
 
   // Assessment sections configuration
@@ -126,16 +126,16 @@ const IdeaDiscoveryAssessment = () => {
     
     // Update overall progress
     const overallProgress = calculateOverallProgress()
-    updateProgress('idea-discovery', overallProgress)
+    updateProgress('idea_discovery', overallProgress)
     
     // Complete phase if all sections are done
     if (overallProgress >= 100 && !ideaDiscoveryData.completed) {
-      completePhase('idea-discovery')
+      completePhase('idea_discovery')
     }
   }, [responses])
 
   const handleResponse = (questionId, answer) => {
-    updateResponse('idea-discovery', questionId, answer, currentSection)
+    updateResponse('idea_discovery', questionId, answer, currentSection)
   }
 
   const nextSection = () => {
@@ -228,8 +228,8 @@ const IdeaDiscoveryAssessment = () => {
         {currentSectionIndex === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase("idea-discovery");
-              updatePhase("market-research");
+              completePhase("idea_discovery");
+              updatePhase("market_research");
             }}
           >
             Next Phase

--- a/changepreneurship-enhanced/src/components/assessment/MarketResearchTools.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/MarketResearchTools.jsx
@@ -44,7 +44,7 @@ const MarketResearchTools = () => {
   const [currentSection, setCurrentSection] = useState('competitive-analysis')
   const [sectionProgress, setSectionProgress] = useState({})
   
-  const marketResearchData = assessmentData['market-research'] || {}
+  const marketResearchData = assessmentData['market_research'] || {}
   const responses = marketResearchData.responses || {}
 
   // Assessment sections configuration
@@ -130,16 +130,16 @@ const MarketResearchTools = () => {
     
     // Update overall progress
     const overallProgress = calculateOverallProgress()
-    updateProgress('market-research', overallProgress)
+    updateProgress('market_research', overallProgress)
     
     // Complete phase if all sections are done
     if (overallProgress >= 100 && !marketResearchData.completed) {
-      completePhase('market-research')
+      completePhase('market_research')
     }
   }, [responses])
 
   const handleResponse = (questionId, answer) => {
-    updateResponse('market-research', questionId, answer, currentSection)
+    updateResponse('market_research', questionId, answer, currentSection)
   }
 
   const nextSection = () => {
@@ -237,8 +237,8 @@ const MarketResearchTools = () => {
         {currentSectionIndex === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase('market-research')
-              updatePhase('business-pillars')
+              completePhase('market_research')
+              updatePhase('business_pillars')
             }}
           >
             Next Phase

--- a/changepreneurship-enhanced/src/components/assessment/ProductConceptTesting.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/ProductConceptTesting.jsx
@@ -224,7 +224,7 @@ const ProductConceptTesting = () => {
 
   // Load existing data (once)
   useEffect(() => {
-    const existingData = assessmentData["product-concept-testing"] || {};
+    const existingData = assessmentData["product_concept_testing"] || {};
     if (Object.keys(existingData).length > 0) {
       setSectionData((prev) => ({ ...prev, ...existingData }));
     }
@@ -236,7 +236,7 @@ const ProductConceptTesting = () => {
   useEffect(() => {
     const serialized = JSON.stringify(sectionData);
     if (serialized !== lastSavedRef.current) {
-      updateAssessmentData("product-concept-testing", sectionData);
+      updateAssessmentData("product_concept_testing", sectionData);
       lastSavedRef.current = serialized;
     }
   }, [sectionData, updateAssessmentData]);
@@ -881,8 +881,8 @@ const ProductConceptTesting = () => {
         {currentSection === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase('product-concept-testing')
-              updatePhase('business-development')
+              completePhase('product_concept_testing')
+              updatePhase('business_development')
             }}
           >
             Next Phase

--- a/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.backup.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.backup.jsx
@@ -127,7 +127,7 @@ const SelfDiscoveryAssessment = () => {
   const [isOptimized, setIsOptimized] = useState(false)
   const [connectedSources, setConnectedSources] = useState([])
   
-  const selfDiscoveryData = assessmentData['self-discovery'] || {}
+  const selfDiscoveryData = assessmentData['self_discovery'] || {}
   const responses = selfDiscoveryData.responses || {}
 
   // Assessment sections configuration
@@ -189,7 +189,7 @@ const SelfDiscoveryAssessment = () => {
   // Handle response updates (✅ argument order fix)
   const handleResponse = (questionId, answer) => {
     // updateResponse(phase, questionId, answer, section)
-    updateResponse('self-discovery', questionId, answer, currentSection)
+    updateResponse('self_discovery', questionId, answer, currentSection)
     
     // Update section progress
     const sectionQuestions = currentSectionData.questions
@@ -209,7 +209,7 @@ const SelfDiscoveryAssessment = () => {
       [currentSection]: progress
     }).filter(p => p === 100).length
     const overall = Math.round((completedSections / totalSections) * 100)
-    updateProgress('self-discovery', overall)
+    updateProgress('self_discovery', overall)
   }
 
   // Handle data import optimization (✅ fixed argument order)
@@ -221,11 +221,11 @@ const SelfDiscoveryAssessment = () => {
     // Simulate pre-population
     if (sources.includes('linkedin')) {
       // motivation → questionId: 'primary-motivation'
-      updateResponse('self-discovery', 'primary-motivation', 'solve-problems', 'motivation')
+      updateResponse('self_discovery', 'primary-motivation', 'solve-problems', 'motivation')
     }
     if (sources.includes('financial')) {
       // confidence → questionId: 'vision-confidence' (number 7)
-      updateResponse('self-discovery', 'vision-confidence', 7, 'confidence')
+      updateResponse('self_discovery', 'vision-confidence', 7, 'confidence')
     }
   }
 

--- a/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx
@@ -181,7 +181,7 @@ const SelfDiscoveryAssessment = () => {
   const [isOptimized, setIsOptimized] = useState(false);
   const [connectedSources, setConnectedSources] = useState([]);
 
-  const selfDiscoveryData = assessmentData["self-discovery"] || {};
+  const selfDiscoveryData = assessmentData["self_discovery"] || {};
   const responses = selfDiscoveryData.responses || {};
 
   // Assessment sections configuration
@@ -245,7 +245,7 @@ const SelfDiscoveryAssessment = () => {
   // Handle response updates (✅ argument order fix)
   const handleResponse = (questionId, answer) => {
     // updateResponse(phase, questionId, answer, section)
-    updateResponse("self-discovery", questionId, answer, currentSection);
+    updateResponse("self_discovery", questionId, answer, currentSection);
 
     // Update section progress
     const sectionQuestions = currentSectionData.questions;
@@ -268,7 +268,7 @@ const SelfDiscoveryAssessment = () => {
       [currentSection]: progress,
     }).filter((p) => p === 100).length;
     const overall = Math.round((completedSections / totalSections) * 100);
-    updateProgress("self-discovery", overall);
+    updateProgress("self_discovery", overall);
   };
 
   // Handle data import optimization using imported data
@@ -304,7 +304,7 @@ const SelfDiscoveryAssessment = () => {
           importedData
         );
         if (pre) {
-          updateResponse("self-discovery", q.id, pre.value, section.id);
+          updateResponse("self_discovery", q.id, pre.value, section.id);
         }
       });
     });
@@ -467,8 +467,8 @@ const SelfDiscoveryAssessment = () => {
         {currentSectionIndex === sections.length - 1 ? (
           <Button
             onClick={() => {
-              completePhase("self-discovery");
-              updatePhase("idea-discovery");
+              completePhase("self_discovery");
+              updatePhase("idea_discovery");
             }}
           >
             Next Phase

--- a/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx.backup
+++ b/changepreneurship-enhanced/src/components/assessment/SelfDiscoveryAssessment.jsx.backup
@@ -35,7 +35,7 @@ const SelfDiscoveryAssessment = () => {
   const [currentSection, setCurrentSection] = useState('motivation')
   const [sectionProgress, setSectionProgress] = useState({})
   
-  const selfDiscoveryData = assessmentData['self-discovery'] || {}
+  const selfDiscoveryData = assessmentData['self_discovery'] || {}
   const responses = selfDiscoveryData.responses || {}
 
   // Assessment sections configuration
@@ -162,17 +162,17 @@ const SelfDiscoveryAssessment = () => {
     
     // Update overall progress
     const overallProgress = calculateOverallProgress()
-    updateProgress('self-discovery', overallProgress)
+    updateProgress('self_discovery', overallProgress)
     
     // Complete phase if all sections are done
     if (overallProgress >= 100 && !selfDiscoveryData.completed) {
-      completePhase('self-discovery')
+      completePhase('self_discovery')
       calculateArchetype(responses)
     }
   }, [responses])
 
   const handleResponse = (questionId, answer) => {
-    updateResponse('self-discovery', questionId, answer, currentSection)
+    updateResponse('self_discovery', questionId, answer, currentSection)
   }
 
   const nextSection = () => {

--- a/changepreneurship-enhanced/src/components/dashboard/UserDashboard.jsx
+++ b/changepreneurship-enhanced/src/components/dashboard/UserDashboard.jsx
@@ -30,13 +30,13 @@ const UserDashboard = () => {
 
   // Phase definitions for the 7-part framework
   const phases = [
-    { id: 'self-discovery', name: 'Self Discovery', duration: '60-90 min', category: 'Foundation' },
-    { id: 'idea-discovery', name: 'Idea Discovery', duration: '90-120 min', category: 'Foundation' },
-    { id: 'market-research', name: 'Market Research', duration: '2-3 weeks', category: 'Foundation' },
-    { id: 'business-pillars', name: 'Business Pillars', duration: '1-2 weeks', category: 'Foundation' },
-    { id: 'product-concept-testing', name: 'Product Concept Testing', duration: '3-4 days', category: 'Implementation' },
-    { id: 'business-development', name: 'Business Development', duration: '1-2 weeks', category: 'Implementation' },
-    { id: 'business-prototype-testing', name: 'Business Prototype Testing', duration: '2-4 weeks', category: 'Implementation' }
+    { id: 'self_discovery', name: 'Self Discovery', duration: '60-90 min', category: 'Foundation' },
+    { id: 'idea_discovery', name: 'Idea Discovery', duration: '90-120 min', category: 'Foundation' },
+    { id: 'market_research', name: 'Market Research', duration: '2-3 weeks', category: 'Foundation' },
+    { id: 'business_pillars', name: 'Business Pillars', duration: '1-2 weeks', category: 'Foundation' },
+    { id: 'product_concept_testing', name: 'Product Concept Testing', duration: '3-4 days', category: 'Implementation' },
+    { id: 'business_development', name: 'Business Development', duration: '1-2 weeks', category: 'Implementation' },
+    { id: 'business_prototype_testing', name: 'Business Prototype Testing', duration: '2-4 weeks', category: 'Implementation' }
   ]
 
   useEffect(() => {
@@ -104,7 +104,7 @@ const UserDashboard = () => {
     if (completedCount >= 7) achievements.push({ name: 'Journey Complete', description: 'Completed the entire assessment', icon: '🏆' })
     
     // Check for specific achievements
-    if (assessmentData['self-discovery']?.archetype) {
+    if (assessmentData['self_discovery']?.archetype) {
       achievements.push({ name: 'Self-Aware', description: 'Discovered your entrepreneur archetype', icon: '🧠' })
     }
     
@@ -391,11 +391,11 @@ const UserDashboard = () => {
                   <CardTitle className="text-white">Entrepreneur Profile</CardTitle>
                 </CardHeader>
                 <CardContent>
-                  {assessmentData['self-discovery']?.archetype ? (
+                  {assessmentData['self_discovery']?.archetype ? (
                     <div className="space-y-4">
                       <div className="text-center">
                         <div className="text-2xl font-bold text-orange-600">
-                          {assessmentData['self-discovery'].archetype.replace('-', ' ').replace(/\b\w/g, l => l.toUpperCase())}
+                          {assessmentData['self_discovery'].archetype.replace('-', ' ').replace(/\b\w/g, l => l.toUpperCase())}
                         </div>
                         <p className="text-gray-400 mt-2">Your Entrepreneur Archetype</p>
                       </div>

--- a/changepreneurship-enhanced/src/contexts/AssessmentContext.jsx
+++ b/changepreneurship-enhanced/src/contexts/AssessmentContext.jsx
@@ -4,21 +4,21 @@ import React, { createContext, useContext, useReducer, useEffect } from "react";
 const initialState = {
   currentPhase: null,
   assessmentData: {
-    "self-discovery": {
+    "self_discovery": {
       completed: false,
       progress: 0,
       responses: {},
       archetype: null,
       insights: {},
     },
-    "idea-discovery": {
+    "idea_discovery": {
       completed: false,
       progress: 0,
       responses: {},
       opportunities: [],
       selectedIdeas: [],
     },
-    "market-research": {
+    "market_research": {
       completed: false,
       progress: 0,
       responses: {},
@@ -27,7 +27,7 @@ const initialState = {
       targetMarket: {},
       marketSize: {},
     },
-    "business-pillars": {
+    "business_pillars": {
       completed: false,
       progress: 0,
       responses: {},
@@ -36,7 +36,7 @@ const initialState = {
       valueProposition: {},
       revenueModel: {},
     },
-    "product-concept-testing": {
+    "product_concept_testing": {
       completed: false,
       progress: 0,
       responses: {},
@@ -45,7 +45,7 @@ const initialState = {
       productValidation: {},
       pricingStrategy: {},
     },
-    "business-development": {
+    "business_development": {
       completed: false,
       progress: 0,
       responses: {},
@@ -54,7 +54,7 @@ const initialState = {
       partnerships: {},
       growthStrategy: {},
     },
-    "business-prototype-testing": {
+    "business_prototype_testing": {
       completed: false,
       progress: 0,
       responses: {},
@@ -174,8 +174,8 @@ function assessmentReducer(state, action) {
         ...state,
         assessmentData: {
           ...state.assessmentData,
-          "self-discovery": {
-            ...state.assessmentData["self-discovery"],
+          "self_discovery": {
+            ...state.assessmentData["self_discovery"],
             archetype: action.payload.archetype,
             insights: action.payload.insights,
           },
@@ -187,10 +187,10 @@ function assessmentReducer(state, action) {
         ...state,
         assessmentData: {
           ...state.assessmentData,
-          "idea-discovery": {
-            ...state.assessmentData["idea-discovery"],
+          "idea_discovery": {
+            ...state.assessmentData["idea_discovery"],
             opportunities: [
-              ...state.assessmentData["idea-discovery"].opportunities,
+              ...state.assessmentData["idea_discovery"].opportunities,
               action.payload,
             ],
           },
@@ -335,13 +335,13 @@ export const ENTREPRENEUR_ARCHETYPES = {
 // Phase validation helper
 const validatePhase = (phase) => {
   const validPhases = [
-    "self-discovery",
-    "idea-discovery",
-    "market-research",
-    "business-pillars",
-    "product-concept-testing",
-    "business-development",
-    "business-prototype-testing",
+    "self_discovery",
+    "idea_discovery",
+    "market_research",
+    "business_pillars",
+    "product_concept_testing",
+    "business_development",
+    "business_prototype_testing",
   ];
   if (!validPhases.includes(phase)) {
     console.warn(
@@ -533,23 +533,23 @@ export function AssessmentProvider({ children }) {
     validatePhase(phase) ? state.assessmentData[phase] || null : null;
   const getAllPhasesCompleted = () =>
     [
-      "self-discovery",
-      "idea-discovery",
-      "market-research",
-      "business-pillars",
-      "product-concept-testing",
-      "business-development",
-      "business-prototype-testing",
+      "self_discovery",
+      "idea_discovery",
+      "market_research",
+      "business_pillars",
+      "product_concept_testing",
+      "business_development",
+      "business_prototype_testing",
     ].every((phase) => state.assessmentData[phase]?.completed === true);
   const getOverallProgress = () => {
     const phases = [
-      "self-discovery",
-      "idea-discovery",
-      "market-research",
-      "business-pillars",
-      "product-concept-testing",
-      "business-development",
-      "business-prototype-testing",
+      "self_discovery",
+      "idea_discovery",
+      "market_research",
+      "business_pillars",
+      "product_concept_testing",
+      "business_development",
+      "business_prototype_testing",
     ];
     const total = phases.reduce(
       (sum, phase) => sum + (state.assessmentData[phase]?.progress || 0),

--- a/changepreneurship-enhanced/src/contexts/EnhancedAssessmentContext.jsx
+++ b/changepreneurship-enhanced/src/contexts/EnhancedAssessmentContext.jsx
@@ -11,9 +11,9 @@ import AdaptiveAssessmentEngine, {
 // Enhanced initial state with adaptive features
 const initialState = {
   // Core assessment data
-  currentPhase: 'self-discovery',
+  currentPhase: 'self_discovery',
   assessmentData: {
-    'self-discovery': {
+    'self_discovery': {
       completed: false,
       progress: 0,
       responses: {},
@@ -23,7 +23,7 @@ const initialState = {
       skippedQuestions: [],
       prePopulatedAnswers: {}
     },
-    'idea-discovery': {
+    'idea_discovery': {
       completed: false,
       progress: 0,
       responses: {},
@@ -33,7 +33,7 @@ const initialState = {
       skippedQuestions: [],
       prePopulatedAnswers: {}
     },
-    'market-research': {
+    'market_research': {
       completed: false,
       progress: 0,
       responses: {},
@@ -43,7 +43,7 @@ const initialState = {
       skippedQuestions: [],
       prePopulatedAnswers: {}
     },
-    'business-pillars': {
+    'business_pillars': {
       completed: false,
       progress: 0,
       responses: {},
@@ -53,7 +53,7 @@ const initialState = {
       skippedQuestions: [],
       prePopulatedAnswers: {}
     },
-    'product-concept-testing': {
+    'product_concept_testing': {
       completed: false,
       progress: 0,
       responses: {},
@@ -62,7 +62,7 @@ const initialState = {
       skippedQuestions: [],
       prePopulatedAnswers: {}
     },
-    'business-development': {
+    'business_development': {
       completed: false,
       progress: 0,
       responses: {},
@@ -71,7 +71,7 @@ const initialState = {
       skippedQuestions: [],
       prePopulatedAnswers: {}
     },
-    'business-prototype-testing': {
+    'business_prototype_testing': {
       completed: false,
       progress: 0,
       responses: {},
@@ -319,8 +319,8 @@ function enhancedAssessmentReducer(state, action) {
         ...state,
         assessmentData: {
           ...state.assessmentData,
-          'self-discovery': {
-            ...state.assessmentData['self-discovery'],
+          'self_discovery': {
+            ...state.assessmentData['self_discovery'],
             archetype: action.payload.archetype,
             insights: action.payload.insights
           }
@@ -332,9 +332,9 @@ function enhancedAssessmentReducer(state, action) {
         ...state,
         assessmentData: {
           ...state.assessmentData,
-          'idea-discovery': {
-            ...state.assessmentData['idea-discovery'],
-            opportunities: [...state.assessmentData['idea-discovery'].opportunities, action.payload]
+          'idea_discovery': {
+            ...state.assessmentData['idea_discovery'],
+            opportunities: [...state.assessmentData['idea_discovery'].opportunities, action.payload]
           }
         }
       }

--- a/changepreneurship-enhanced/src/lib/navigation-structure.js
+++ b/changepreneurship-enhanced/src/lib/navigation-structure.js
@@ -13,7 +13,7 @@ export async function getNavigationStructure() {
   }));
   return [
     {
-      id: 'self-discovery',
+      id: 'self_discovery',
       code: 1,
       order: 1,
       title: 'Self Discovery',


### PR DESCRIPTION
## Summary
- replace hyphenated assessment phase keys with underscore variants in the enhanced assessment context and shared state
- update enhanced front-end navigation and components to reference the underscore identifiers for all assessment phases
- confirm the backend assessment routes already expose the underscore-based phase IDs

## Testing
- pnpm lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c93a3c986c8321ab4ee5ba031474c9