### PR TITLE
Make registration transactional and add regression test

### DIFF
--- a/changepreneurship-backend/src/routes/auth.py
+++ b/changepreneurship-backend/src/routes/auth.py
@@ -76,13 +76,14 @@ def register():
                 return jsonify({'error': 'Email already registered'}), 409
 
         password_hash = generate_password_hash(password)
-        user = User(username=username, email=email, password_hash=password_hash)
-        db.session.add(user)
-        db.session.commit()
 
-        profile = EntrepreneurProfile(user_id=user.id)
-        db.session.add(profile)
-        db.session.commit()
+        with db.session.begin():
+            user = User(username=username, email=email, password_hash=password_hash)
+            db.session.add(user)
+            db.session.flush()  # Ensure user ID is available for the profile
+
+            profile = EntrepreneurProfile(user_id=user.id)
+            db.session.add(profile)
 
         session = create_user_session(user.id)
 

--- a/changepreneurship-backend/tests/conftest.py
+++ b/changepreneurship-backend/tests/conftest.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SRC_PATH = os.path.join(PROJECT_ROOT, "src")
+if SRC_PATH not in sys.path:
+    sys.path.insert(0, SRC_PATH)
+
+
+from src.models.assessment import db
+from src.routes.auth import auth_bp
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.config.update(
+        TESTING=True,
+        SQLALCHEMY_DATABASE_URI="sqlite:///:memory:",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        SECRET_KEY="test-secret-key",
+    )
+
+    db.init_app(app)
+    app.register_blueprint(auth_bp, url_prefix="/api/auth")
+
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/changepreneurship-backend/tests/test_auth.py
+++ b/changepreneurship-backend/tests/test_auth.py
@@ -1,0 +1,22 @@
+from src.models.assessment import User
+from src.routes import auth as auth_module
+
+
+def test_register_rolls_back_user_on_profile_failure(app, client, monkeypatch):
+    def failing_profile(*args, **kwargs):
+        raise RuntimeError("Simulated failure while creating profile")
+
+    monkeypatch.setattr(auth_module, "EntrepreneurProfile", failing_profile)
+
+    payload = {
+        "username": "testuser",
+        "email": "test@example.com",
+        "password": "Password123",
+    }
+
+    response = client.post("/api/auth/register", json=payload)
+
+    assert response.status_code == 500
+
+    with app.app_context():
+        assert User.query.count() == 0


### PR DESCRIPTION
## Summary
- wrap user and profile creation in a single database transaction during registration
- add pytest fixtures for setting up an isolated auth blueprint test app
- add a regression test confirming registration rolls back when profile creation fails

## Testing
- pytest changepreneurship-backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68c93b99bfbc832191ab5bade8b06824