### PR TITLE
Ensure assessment responses update types and values

### DIFF
--- a/changepreneurship-backend/src/routes/assessment.py
+++ b/changepreneurship-backend/src/routes/assessment.py
@@ -1,6 +1,5 @@
 from flask import Blueprint, request, jsonify, current_app
 from datetime import datetime
-import json
 
 from src.models.assessment import db, Assessment, AssessmentResponse, EntrepreneurProfile
 from src.utils.auth import verify_session_token
@@ -187,7 +186,11 @@ def save_response(assessment_id):
         
         if existing_response:
             # Update existing response
-            existing_response.response_value = json.dumps(response_value) if isinstance(response_value, (dict, list)) else str(response_value)
+            existing_response.set_response_value(response_value)
+            if response_type:
+                existing_response.response_type = response_type
+            if question_text:
+                existing_response.question_text = question_text
             existing_response.updated_at = datetime.utcnow()
         else:
             # Create new response

--- a/changepreneurship-backend/tests/conftest.py
+++ b/changepreneurship-backend/tests/conftest.py
@@ -13,6 +13,7 @@ if SRC_PATH not in sys.path:
 
 from src.models.assessment import db
 from src.routes.auth import auth_bp
+from src.routes.assessment import assessment_bp
 
 
 @pytest.fixture
@@ -27,6 +28,7 @@ def app():
 
     db.init_app(app)
     app.register_blueprint(auth_bp, url_prefix="/api/auth")
+    app.register_blueprint(assessment_bp, url_prefix="/api/assessment")
 
     with app.app_context():
         db.create_all()

--- a/changepreneurship-backend/tests/test_assessment.py
+++ b/changepreneurship-backend/tests/test_assessment.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timedelta
+
+from src.models.assessment import (
+    Assessment,
+    AssessmentResponse,
+    User,
+    UserSession,
+    db,
+)
+
+
+
+def test_save_response_updates_existing_response(app, client):
+    with app.app_context():
+        user = User(username="tester", email="tester@example.com", password_hash="hashed")
+        db.session.add(user)
+        db.session.flush()
+
+        session = UserSession(
+            user_id=user.id,
+            session_token="test-token",
+            expires_at=datetime.utcnow() + timedelta(days=1),
+            is_active=True,
+        )
+        db.session.add(session)
+
+        assessment = Assessment(
+            user_id=user.id,
+            phase_id="self_discovery",
+            phase_name="Self Discovery",
+            started_at=datetime.utcnow(),
+        )
+        db.session.add(assessment)
+        db.session.flush()
+
+        existing_response = AssessmentResponse(
+            assessment_id=assessment.id,
+            section_id="section-1",
+            question_id="q1",
+            question_text="Original question",
+            response_type="text",
+        )
+        existing_response.set_response_value("Original answer")
+        db.session.add(existing_response)
+        db.session.commit()
+
+        assessment_id = assessment.id
+        question_id = existing_response.question_id
+
+    payload = {
+        "section_id": "section-1",
+        "question_id": question_id,
+        "question_text": "Updated question",
+        "response_type": "json",
+        "response_value": {"answer": ["A", "B"]},
+    }
+    headers = {"Authorization": "Bearer test-token"}
+
+    response = client.post(
+        f"/api/assessment/{assessment_id}/response",
+        json=payload,
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+
+    with app.app_context():
+        updated_response = AssessmentResponse.query.filter_by(
+            assessment_id=assessment_id, question_id=question_id
+        ).one()
+
+        assert updated_response.response_type == "json"
+        assert updated_response.question_text == "Updated question"
+        assert updated_response.get_response_value() == {"answer": ["A", "B"]}
+        assert updated_response.updated_at is not None


### PR DESCRIPTION
## Summary
- use the model helper to persist updated assessment response values
- refresh stored response type and text when the payload changes them
- register the assessment routes for testing and cover type-changing updates in pytest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93dec4e088321ac4288eabab57d1f