### PR TITLE
Validate progress percentage input

### DIFF
--- a/changepreneurship-backend/src/routes/assessment.py
+++ b/changepreneurship-backend/src/routes/assessment.py
@@ -238,7 +238,12 @@ def update_progress(assessment_id):
         assessment_data = data.get('assessment_data', {})
         
         if progress_percentage is not None:
-            assessment.progress_percentage = max(0, min(100, float(progress_percentage)))
+            try:
+                progress_value = float(progress_percentage)
+            except (TypeError, ValueError):
+                return jsonify({'error': 'Invalid progress_percentage. Must be a numeric value.'}), 400
+
+            assessment.progress_percentage = max(0, min(100, progress_value))
         
         if is_completed:
             assessment.is_completed = True

--- a/changepreneurship-backend/tests/test_assessment.py
+++ b/changepreneurship-backend/tests/test_assessment.py
@@ -9,6 +9,32 @@ from src.models.assessment import (
 )
 
 
+def create_assessment_with_session(app, session_token):
+    with app.app_context():
+        user = User(username="tester", email=f"{session_token}@example.com", password_hash="hashed")
+        db.session.add(user)
+        db.session.flush()
+
+        session = UserSession(
+            user_id=user.id,
+            session_token=session_token,
+            expires_at=datetime.utcnow() + timedelta(days=1),
+            is_active=True,
+        )
+        db.session.add(session)
+
+        assessment = Assessment(
+            user_id=user.id,
+            phase_id="self_discovery",
+            phase_name="Self Discovery",
+            started_at=datetime.utcnow(),
+        )
+        db.session.add(assessment)
+        db.session.commit()
+
+        return assessment.id
+
+
 
 def test_save_response_updates_existing_response(app, client):
     with app.app_context():
@@ -73,3 +99,60 @@ def test_save_response_updates_existing_response(app, client):
         assert updated_response.question_text == "Updated question"
         assert updated_response.get_response_value() == {"answer": ["A", "B"]}
         assert updated_response.updated_at is not None
+
+
+def test_update_progress_valid_value(app, client):
+    assessment_id = create_assessment_with_session(app, "token-progress-valid")
+    headers = {"Authorization": "Bearer token-progress-valid"}
+
+    response = client.put(
+        f"/api/assessment/{assessment_id}/progress",
+        json={"progress_percentage": 45.5},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["assessment"]["progress_percentage"] == 45.5
+
+    with app.app_context():
+        assessment = Assessment.query.get(assessment_id)
+        assert assessment.progress_percentage == 45.5
+
+
+def test_update_progress_rejects_non_numeric_value(app, client):
+    assessment_id = create_assessment_with_session(app, "token-progress-invalid")
+    headers = {"Authorization": "Bearer token-progress-invalid"}
+
+    response = client.put(
+        f"/api/assessment/{assessment_id}/progress",
+        json={"progress_percentage": "not-a-number"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    data = response.get_json()
+    assert data["error"] == "Invalid progress_percentage. Must be a numeric value."
+
+    with app.app_context():
+        assessment = Assessment.query.get(assessment_id)
+        assert assessment.progress_percentage == 0.0
+
+
+def test_update_progress_clamps_out_of_range_value(app, client):
+    assessment_id = create_assessment_with_session(app, "token-progress-out-of-range")
+    headers = {"Authorization": "Bearer token-progress-out-of-range"}
+
+    response = client.put(
+        f"/api/assessment/{assessment_id}/progress",
+        json={"progress_percentage": 150},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data["assessment"]["progress_percentage"] == 100.0
+
+    with app.app_context():
+        assessment = Assessment.query.get(assessment_id)
+        assert assessment.progress_percentage == 100.0


### PR DESCRIPTION
## Summary
- wrap progress percentage parsing in a try/except and return a 400 when the value is invalid
- add a helper to create assessments with sessions for tests
- add coverage for valid, non-numeric, and out-of-range progress updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c93f7eda1083218d42ca7d5ada698c