### PR TITLE
Ensure user and profile register in single transaction

### DIFF
--- a/changepreneurship-backend/src/routes/auth.py
+++ b/changepreneurship-backend/src/routes/auth.py
@@ -77,13 +77,13 @@ def register():
 
         password_hash = generate_password_hash(password)
 
-        with db.session.begin():
-            user = User(username=username, email=email, password_hash=password_hash)
-            db.session.add(user)
-            db.session.flush()  # Ensure user ID is available for the profile
+        user = User(username=username, email=email, password_hash=password_hash)
+        db.session.add(user)
+        db.session.flush()  # Ensure user ID is available for the profile
 
-            profile = EntrepreneurProfile(user_id=user.id)
-            db.session.add(profile)
+        profile = EntrepreneurProfile(user_id=user.id)
+        db.session.add(profile)
+        db.session.commit()
 
         session = create_user_session(user.id)
 

--- a/changepreneurship-backend/tests/test_auth.py
+++ b/changepreneurship-backend/tests/test_auth.py
@@ -1,4 +1,4 @@
-from src.models.assessment import User
+from src.models.assessment import User, EntrepreneurProfile
 from src.routes import auth as auth_module
 
 
@@ -20,3 +20,4 @@ def test_register_rolls_back_user_on_profile_failure(app, client, monkeypatch):
 
     with app.app_context():
         assert User.query.count() == 0
+        assert EntrepreneurProfile.query.count() == 0


### PR DESCRIPTION
## Summary
- persist new users and their entrepreneur profiles within an explicit session commit so both inserts share a transaction
- extend the registration rollback regression test to assert neither users nor profiles remain after a forced failure

## Testing
- pytest tests/test_auth.py

------
https://chatgpt.com/codex/tasks/task_e_68cac3a11c748321bda1bb67be64d25f