### PR TITLE
Use stable navigation identifiers and add regression test

### DIFF
--- a/changepreneurship-enhanced/package.json
+++ b/changepreneurship-enhanced/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/changepreneurship-enhanced/src/components/assessment/ComprehensiveQuestionBank.jsx
+++ b/changepreneurship-enhanced/src/components/assessment/ComprehensiveQuestionBank.jsx
@@ -2,259 +2,349 @@
 // This file contains all question data for the complete 7-part assessment framework
 
 export const SELF_DISCOVERY_QUESTIONS = {
-  motivation: [
-    {
-      id: 'primary-motivation',
-      question: 'What is the main reason you want to start your own business?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'transform-world', label: 'Create something that changes the world', description: 'Build transformative solutions for the future' },
-        { value: 'solve-problems', label: 'Solve real problems I see everywhere', description: 'Fix immediate problems with practical solutions' },
-        { value: 'lifestyle-freedom', label: 'Have the lifestyle and freedom I want', description: 'Personal freedom and lifestyle alignment' },
-        { value: 'financial-security', label: 'Build financial security for my family', description: 'Stable income and asset building' },
-        { value: 'social-impact', label: 'Make a positive difference in the world', description: 'Social or environmental impact' },
-        { value: 'seize-opportunities', label: 'Capture market opportunities I see', description: 'Seize opportunities for profit' }
-      ]
-    },
-    {
-      id: 'success-vision',
-      question: 'When you imagine your business being successful, what does that look like?',
-      type: 'textarea',
-      required: true,
-      placeholder: 'Describe your vision of success in detail...',
-      helpText: 'Think about team size, daily life, impact, working hours, and what success means to you personally.'
-    },
-    {
-      id: 'risk-tolerance',
-      question: 'How comfortable are you with taking risks?',
-      type: 'scale',
-      required: true,
-      scaleRange: { min: 1, max: 10 },
-      scaleLabels: { min: 'Very Risk-Averse', max: 'High Risk Tolerance' },
-      helpText: 'Consider both financial and personal risks involved in starting a business.'
-    },
-    {
-      id: 'entrepreneurial-drive',
-      question: 'What drives you to consider entrepreneurship over traditional employment?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'autonomy', label: 'Need for autonomy and control', description: 'Want to be my own boss' },
-        { value: 'creativity', label: 'Creative expression and innovation', description: 'Build something new and unique' },
-        { value: 'impact', label: 'Desire to make a bigger impact', description: 'Create meaningful change' },
-        { value: 'financial', label: 'Financial independence and wealth', description: 'Build significant wealth' },
-        { value: 'flexibility', label: 'Work-life balance and flexibility', description: 'Control my schedule and location' },
-        { value: 'legacy', label: 'Building a lasting legacy', description: 'Create something that outlasts me' }
-      ]
-    },
-    {
-      id: 'failure-perspective',
-      question: 'How do you view the possibility of business failure?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'learning', label: 'Learning opportunity and stepping stone', description: 'Failure teaches valuable lessons' },
-        { value: 'acceptable-risk', label: 'Acceptable risk for potential rewards', description: 'Worth the risk for success' },
-        { value: 'concerning', label: 'Concerning but manageable', description: 'Worried but can handle it' },
-        { value: 'devastating', label: 'Potentially devastating outcome', description: 'Would be very difficult to recover' }
-      ]
-    }
-  ],
-  
-  'life-impact': [
-    {
-      id: 'life-satisfaction',
-      question: 'Rate your current satisfaction in different life areas',
-      type: 'multiple-scale',
-      required: true,
-      areas: ['Health', 'Money', 'Family', 'Friends', 'Career', 'Growth', 'Recreation', 'Environment'],
-      scaleRange: { min: 1, max: 10 }
-    },
-    {
-      id: 'time-commitment',
-      question: 'How many hours per week are you willing to dedicate to building your business?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: '10-20', label: '10-20 hours (side project)', description: 'Part-time while keeping current job' },
-        { value: '20-40', label: '20-40 hours (significant commitment)', description: 'Major time investment' },
-        { value: '40-60', label: '40-60 hours (full-time focus)', description: 'Primary focus and dedication' },
-        { value: '60+', label: '60+ hours (all-in commitment)', description: 'Complete dedication to success' }
-      ]
-    },
-    {
-      id: 'family-support',
-      question: 'How supportive is your family/partner of your entrepreneurial goals?',
-      type: 'scale',
-      required: true,
-      scaleRange: { min: 1, max: 10 },
-      scaleLabels: { min: 'Not Supportive', max: 'Very Supportive' },
-      helpText: 'Consider emotional, financial, and practical support from those closest to you.'
-    },
-    {
-      id: 'stress-management',
-      question: 'How do you typically handle high-stress situations?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'thrive', label: 'I thrive under pressure', description: 'Stress motivates and energizes me' },
-        { value: 'manage-well', label: 'I manage stress effectively', description: 'Have good coping strategies' },
-        { value: 'struggle-sometimes', label: 'I struggle sometimes but cope', description: 'Can be challenging but manageable' },
-        { value: 'avoid-stress', label: 'I prefer to avoid stressful situations', description: 'Stress negatively impacts my performance' }
-      ]
-    },
-    {
-      id: 'work-life-balance',
-      question: 'What does ideal work-life balance look like for you?',
-      type: 'textarea',
-      required: true,
-      placeholder: 'Describe your ideal balance between work and personal life...',
-      helpText: 'Consider family time, hobbies, health, and personal relationships.'
-    }
-  ],
+  motivation: {
+    id: 'motivation',
+    code: 1,
+    order: 1,
+    title: 'Motivation & Drive',
+    questions: [
+      {
+        id: 'primary-motivation',
+        code: 1,
+        order: 1,
+        question: 'What is the main reason you want to start your own business?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'transform-world', label: 'Create something that changes the world', description: 'Build transformative solutions for the future' },
+          { value: 'solve-problems', label: 'Solve real problems I see everywhere', description: 'Fix immediate problems with practical solutions' },
+          { value: 'lifestyle-freedom', label: 'Have the lifestyle and freedom I want', description: 'Personal freedom and lifestyle alignment' },
+          { value: 'financial-security', label: 'Build financial security for my family', description: 'Stable income and asset building' },
+          { value: 'social-impact', label: 'Make a positive difference in the world', description: 'Social or environmental impact' },
+          { value: 'seize-opportunities', label: 'Capture market opportunities I see', description: 'Seize opportunities for profit' }
+        ]
+      },
+      {
+        id: 'success-vision',
+        code: 2,
+        order: 2,
+        question: 'When you imagine your business being successful, what does that look like?',
+        type: 'textarea',
+        required: true,
+        placeholder: 'Describe your vision of success in detail...',
+        helpText: 'Think about team size, daily life, impact, working hours, and what success means to you personally.'
+      },
+      {
+        id: 'risk-tolerance',
+        code: 3,
+        order: 3,
+        question: 'How comfortable are you with taking risks?',
+        type: 'scale',
+        required: true,
+        scaleRange: { min: 1, max: 10 },
+        scaleLabels: { min: 'Very Risk-Averse', max: 'High Risk Tolerance' },
+        helpText: 'Consider both financial and personal risks involved in starting a business.'
+      },
+      {
+        id: 'entrepreneurial-drive',
+        code: 4,
+        order: 4,
+        question: 'What drives you to consider entrepreneurship over traditional employment?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'autonomy', label: 'Need for autonomy and control', description: 'Want to be my own boss' },
+          { value: 'creativity', label: 'Creative expression and innovation', description: 'Build something new and unique' },
+          { value: 'impact', label: 'Desire to make a bigger impact', description: 'Create meaningful change' },
+          { value: 'financial', label: 'Financial independence and wealth', description: 'Build significant wealth' },
+          { value: 'flexibility', label: 'Work-life balance and flexibility', description: 'Control my schedule and location' },
+          { value: 'legacy', label: 'Building a lasting legacy', description: 'Create something that outlasts me' }
+        ]
+      },
+      {
+        id: 'failure-perspective',
+        code: 5,
+        order: 5,
+        question: 'How do you view the possibility of business failure?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'learning', label: 'Learning opportunity and stepping stone', description: 'Failure teaches valuable lessons' },
+          { value: 'acceptable-risk', label: 'Acceptable risk for potential rewards', description: 'Worth the risk for success' },
+          { value: 'concerning', label: 'Concerning but manageable', description: 'Worried but can handle it' },
+          { value: 'devastating', label: 'Potentially devastating outcome', description: 'Would be very difficult to recover' }
+        ]
+      }
+    ]
+  },
 
-  values: [
-    {
-      id: 'top-values',
-      question: 'Rank these values in order of importance to you',
-      type: 'ranking',
-      required: true,
-      options: [
-        { value: 'financial-success', label: 'Financial Success' },
-        { value: 'personal-freedom', label: 'Personal Freedom' },
-        { value: 'family-time', label: 'Family Time' },
-        { value: 'making-difference', label: 'Making a Difference' },
-        { value: 'recognition', label: 'Recognition' },
-        { value: 'learning', label: 'Learning' },
-        { value: 'security', label: 'Security' },
-        { value: 'adventure', label: 'Adventure' }
-      ]
-    },
-    {
-      id: 'ethical-standards',
-      question: 'How important are ethical business practices to you?',
-      type: 'scale',
-      required: true,
-      scaleRange: { min: 1, max: 10 },
-      scaleLabels: { min: 'Not Important', max: 'Extremely Important' },
-      helpText: 'Consider environmental responsibility, fair treatment of employees, and honest business practices.'
-    },
-    {
-      id: 'decision-making-style',
-      question: 'How do you prefer to make important decisions?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'data-driven', label: 'Based on data and analysis', description: 'Research thoroughly before deciding' },
-        { value: 'intuitive', label: 'Trust my gut instincts', description: 'Rely on intuition and experience' },
-        { value: 'collaborative', label: 'Seek input from others', description: 'Consult with advisors and team' },
-        { value: 'quick-decisive', label: 'Make quick, decisive choices', description: 'Decide fast and adjust as needed' }
-      ]
-    },
-    {
-      id: 'money-motivation',
-      question: 'What role does money play in your motivation to start a business?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'primary', label: 'Primary motivator', description: 'Financial success is the main goal' },
-        { value: 'important', label: 'Important but not primary', description: 'Necessary for other goals' },
-        { value: 'secondary', label: 'Secondary consideration', description: 'Nice to have but not essential' },
-        { value: 'minimal', label: 'Minimal importance', description: 'Not a significant factor' }
-      ]
-    }
-  ],
+  'life-impact': {
+    id: 'life-impact',
+    code: 2,
+    order: 2,
+    title: 'Life Impact & Support',
+    questions: [
+      {
+        id: 'life-satisfaction',
+        code: 1,
+        order: 1,
+        question: 'Rate your current satisfaction in different life areas',
+        type: 'multiple-scale',
+        required: true,
+        areas: ['Health', 'Money', 'Family', 'Friends', 'Career', 'Growth', 'Recreation', 'Environment'],
+        scaleRange: { min: 1, max: 10 }
+      },
+      {
+        id: 'time-commitment',
+        code: 2,
+        order: 2,
+        question: 'How many hours per week are you willing to dedicate to building your business?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: '10-20', label: '10-20 hours (side project)', description: 'Part-time while keeping current job' },
+          { value: '20-40', label: '20-40 hours (significant commitment)', description: 'Major time investment' },
+          { value: '40-60', label: '40-60 hours (full-time focus)', description: 'Primary focus and dedication' },
+          { value: '60+', label: '60+ hours (all-in commitment)', description: 'Complete dedication to success' }
+        ]
+      },
+      {
+        id: 'family-support',
+        code: 3,
+        order: 3,
+        question: 'How supportive is your family/partner of your entrepreneurial goals?',
+        type: 'scale',
+        required: true,
+        scaleRange: { min: 1, max: 10 },
+        scaleLabels: { min: 'Not Supportive', max: 'Very Supportive' },
+        helpText: 'Consider emotional, financial, and practical support from those closest to you.'
+      },
+      {
+        id: 'stress-management',
+        code: 4,
+        order: 4,
+        question: 'How do you typically handle high-stress situations?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'thrive', label: 'I thrive under pressure', description: 'Stress motivates and energizes me' },
+          { value: 'manage-well', label: 'I manage stress effectively', description: 'Have good coping strategies' },
+          { value: 'struggle-sometimes', label: 'I struggle sometimes but cope', description: 'Can be challenging but manageable' },
+          { value: 'avoid-stress', label: 'I prefer to avoid stressful situations', description: 'Stress negatively impacts my performance' }
+        ]
+      },
+      {
+        id: 'work-life-balance',
+        code: 5,
+        order: 5,
+        question: 'What does ideal work-life balance look like for you?',
+        type: 'textarea',
+        required: true,
+        placeholder: 'Describe your ideal balance between work and personal life...',
+        helpText: 'Consider family time, hobbies, health, and personal relationships.'
+      }
+    ]
+  },
 
-  vision: [
-    {
-      id: 'ten-year-vision',
-      question: 'Describe your ideal life 10 years from now',
-      type: 'textarea',
-      required: true,
-      placeholder: 'Paint a detailed picture of your future self...',
-      helpText: 'Include your age, how you feel, your identity, contributions, achievements, and relationships.'
-    },
-    {
-      id: 'business-size-preference',
-      question: 'What size business do you envision building?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'solo', label: 'Solo business (just me)', description: 'Freelancer or consultant model' },
-        { value: 'small-team', label: 'Small team (2-10 people)', description: 'Boutique or specialized service' },
-        { value: 'medium', label: 'Medium business (10-50 people)', description: 'Regional or niche market leader' },
-        { value: 'large', label: 'Large company (50+ people)', description: 'Significant market presence' },
-        { value: 'enterprise', label: 'Enterprise/Corporation', description: 'Major industry player' }
-      ]
-    },
-    {
-      id: 'impact-scope',
-      question: 'What scope of impact do you want your business to have?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'local', label: 'Local community impact', description: 'Serve my immediate community' },
-        { value: 'regional', label: 'Regional or state-wide impact', description: 'Broader geographic reach' },
-        { value: 'national', label: 'National market presence', description: 'Country-wide influence' },
-        { value: 'global', label: 'Global reach and impact', description: 'International presence' },
-        { value: 'industry', label: 'Transform an entire industry', description: 'Revolutionary change' }
-      ]
-    },
-    {
-      id: 'legacy-importance',
-      question: 'How important is leaving a lasting legacy through your business?',
-      type: 'scale',
-      required: true,
-      scaleRange: { min: 1, max: 10 },
-      scaleLabels: { min: 'Not Important', max: 'Extremely Important' },
-      helpText: 'Consider whether you want your business to outlast you and create lasting change.'
-    }
-  ],
+  values: {
+    id: 'values',
+    code: 3,
+    order: 3,
+    title: 'Values & Ethics',
+    questions: [
+      {
+        id: 'top-values',
+        code: 1,
+        order: 1,
+        question: 'Rank these values in order of importance to you',
+        type: 'ranking',
+        required: true,
+        options: [
+          { value: 'financial-success', label: 'Financial Success' },
+          { value: 'personal-freedom', label: 'Personal Freedom' },
+          { value: 'family-time', label: 'Family Time' },
+          { value: 'making-difference', label: 'Making a Difference' },
+          { value: 'recognition', label: 'Recognition' },
+          { value: 'learning', label: 'Learning' },
+          { value: 'security', label: 'Security' },
+          { value: 'adventure', label: 'Adventure' }
+        ]
+      },
+      {
+        id: 'ethical-standards',
+        code: 2,
+        order: 2,
+        question: 'How important are ethical business practices to you?',
+        type: 'scale',
+        required: true,
+        scaleRange: { min: 1, max: 10 },
+        scaleLabels: { min: 'Not Important', max: 'Extremely Important' },
+        helpText: 'Consider environmental responsibility, fair treatment of employees, and honest business practices.'
+      },
+      {
+        id: 'decision-making-style',
+        code: 3,
+        order: 3,
+        question: 'How do you prefer to make important decisions?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'data-driven', label: 'Based on data and analysis', description: 'Research thoroughly before deciding' },
+          { value: 'intuitive', label: 'Trust my gut instincts', description: 'Rely on intuition and experience' },
+          { value: 'collaborative', label: 'Seek input from others', description: 'Consult with advisors and team' },
+          { value: 'quick-decisive', label: 'Make quick, decisive choices', description: 'Decide fast and adjust as needed' }
+        ]
+      },
+      {
+        id: 'money-motivation',
+        code: 4,
+        order: 4,
+        question: 'What role does money play in your motivation to start a business?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'primary', label: 'Primary motivator', description: 'Financial success is the main goal' },
+          { value: 'important', label: 'Important but not primary', description: 'Necessary for other goals' },
+          { value: 'secondary', label: 'Secondary consideration', description: 'Nice to have but not essential' },
+          { value: 'minimal', label: 'Minimal importance', description: 'Not a significant factor' }
+        ]
+      }
+    ]
+  },
 
-  confidence: [
+  vision: {
+    id: 'vision',
+    code: 4,
+    order: 4,
+    title: 'Vision & Impact',
+    questions: [
+      {
+        id: 'ten-year-vision',
+        code: 1,
+        order: 1,
+        question: 'Describe your ideal life 10 years from now',
+        type: 'textarea',
+        required: true,
+        placeholder: 'Paint a detailed picture of your future self...',
+        helpText: 'Include your age, how you feel, your identity, contributions, achievements, and relationships.'
+      },
+      {
+        id: 'business-size-preference',
+        code: 2,
+        order: 2,
+        question: 'What size business do you envision building?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'solo', label: 'Solo business (just me)', description: 'Freelancer or consultant model' },
+          { value: 'small-team', label: 'Small team (2-10 people)', description: 'Boutique or specialized service' },
+          { value: 'medium', label: 'Medium business (10-50 people)', description: 'Regional or niche market leader' },
+          { value: 'large', label: 'Large company (50+ people)', description: 'Significant market presence' },
+          { value: 'enterprise', label: 'Enterprise/Corporation', description: 'Major industry player' }
+        ]
+      },
+      {
+        id: 'impact-scope',
+        code: 3,
+        order: 3,
+        question: 'What scope of impact do you want your business to have?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'local', label: 'Local community impact', description: 'Serve my immediate community' },
+          { value: 'regional', label: 'Regional or state-wide impact', description: 'Broader geographic reach' },
+          { value: 'national', label: 'National market presence', description: 'Country-wide influence' },
+          { value: 'global', label: 'Global reach and impact', description: 'International presence' },
+          { value: 'industry', label: 'Transform an entire industry', description: 'Revolutionary change' }
+        ]
+      },
+      {
+        id: 'legacy-importance',
+        code: 4,
+        order: 4,
+        question: 'How important is leaving a lasting legacy through your business?',
+        type: 'scale',
+        required: true,
+        scaleRange: { min: 1, max: 10 },
+        scaleLabels: { min: 'Not Important', max: 'Extremely Important' },
+        helpText: 'Consider whether you want your business to outlast you and create lasting change.'
+      }
+    ]
+  },
+
+  confidence: {
+    id: 'confidence',
+    code: 5,
+    order: 5,
+    title: 'Confidence & Skills',
+    questions: [
+      {
+        id: 'vision-confidence',
+        code: 1,
+        order: 1,
+        question: 'How confident are you that you can achieve your 10-year vision?',
+        type: 'scale',
+        required: true,
+        scaleRange: { min: 1, max: 10 },
+        scaleLabels: { min: 'Not Confident', max: 'Very Confident' }
+      },
+      {
+        id: 'skill-confidence',
+        code: 2,
+        order: 2,
+        question: 'Rate your confidence in these key entrepreneurial skills',
+        type: 'multiple-scale',
+        required: true,
+        areas: ['Leadership', 'Sales', 'Marketing', 'Finance', 'Strategy', 'Operations', 'Technology', 'Networking'],
+        scaleRange: { min: 1, max: 10 }
+      },
+      {
+        id: 'learning-approach',
+        code: 3,
+        order: 3,
+        question: 'How do you prefer to learn new skills needed for your business?',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'self-taught', label: 'Self-taught through research', description: 'Books, online courses, trial and error' },
+          { value: 'mentorship', label: 'Mentorship and coaching', description: 'Learn from experienced entrepreneurs' },
+          { value: 'formal-education', label: 'Formal education and training', description: 'Courses, certifications, degrees' },
+          { value: 'hands-on', label: 'Hands-on experience', description: 'Learn by doing and making mistakes' }
+        ]
+      },
+      {
+        id: 'obstacle-handling',
+        code: 4,
+        order: 4,
+        question: 'When you encounter major obstacles, you typically:',
+        type: 'multiple-choice',
+        required: true,
+        options: [
+          { value: 'persist', label: 'Persist until I find a solution', description: 'Never give up, keep trying' },
+          { value: 'adapt', label: 'Adapt my approach and pivot', description: 'Flexible and willing to change' },
+          { value: 'seek-help', label: 'Seek help and advice', description: 'Leverage others\' expertise' },
+          { value: 'step-back', label: 'Step back and reassess', description: 'Take time to think strategically' }
+        ]
+      }
+    ]
+  }
+};
+
+export const SELF_DISCOVERY_NAVIGATION = {
+  id: 'self_discovery',
+  code: 1,
+  order: 1,
+  title: 'Self Discovery',
+  tabs: [
     {
-      id: 'vision-confidence',
-      question: 'How confident are you that you can achieve your 10-year vision?',
-      type: 'scale',
-      required: true,
-      scaleRange: { min: 1, max: 10 },
-      scaleLabels: { min: 'Not Confident', max: 'Very Confident' }
+      id: 'assessment',
+      code: 1,
+      order: 1,
+      title: 'Assessment',
+      sectionIds: ['motivation', 'life-impact', 'values', 'vision', 'confidence'],
     },
-    {
-      id: 'skill-confidence',
-      question: 'Rate your confidence in these key entrepreneurial skills',
-      type: 'multiple-scale',
-      required: true,
-      areas: ['Leadership', 'Sales', 'Marketing', 'Finance', 'Strategy', 'Operations', 'Technology', 'Networking'],
-      scaleRange: { min: 1, max: 10 }
-    },
-    {
-      id: 'learning-approach',
-      question: 'How do you prefer to learn new skills needed for your business?',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'self-taught', label: 'Self-taught through research', description: 'Books, online courses, trial and error' },
-        { value: 'mentorship', label: 'Mentorship and coaching', description: 'Learn from experienced entrepreneurs' },
-        { value: 'formal-education', label: 'Formal education and training', description: 'Courses, certifications, degrees' },
-        { value: 'hands-on', label: 'Hands-on experience', description: 'Learn by doing and making mistakes' }
-      ]
-    },
-    {
-      id: 'obstacle-handling',
-      question: 'When you encounter major obstacles, you typically:',
-      type: 'multiple-choice',
-      required: true,
-      options: [
-        { value: 'persist', label: 'Persist until I find a solution', description: 'Never give up, keep trying' },
-        { value: 'adapt', label: 'Adapt my approach and pivot', description: 'Flexible and willing to change' },
-        { value: 'seek-help', label: 'Seek help and advice', description: 'Leverage others\' expertise' },
-        { value: 'step-back', label: 'Step back and reassess', description: 'Take time to think strategically' }
-      ]
-    }
-  ]
-}
+  ],
+};
 
 export const IDEA_DISCOVERY_QUESTIONS = {
   'core-alignment': [

--- a/changepreneurship-enhanced/src/lib/navigation.test.js
+++ b/changepreneurship-enhanced/src/lib/navigation.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { fromCode, normalizePath } from './navigation.js';
+
+const buildStructure = () => [
+  {
+    id: 'phase-5',
+    code: 5,
+    order: 1,
+    title: 'Phase Five',
+    tabs: [
+      {
+        id: 'tab-2',
+        code: 2,
+        order: 1,
+        title: 'Tab Two',
+        sections: [
+          {
+            id: 'section-a',
+            code: 7,
+            order: 1,
+            title: 'Section A',
+            questions: [
+              { id: 'question-a', code: 3, order: 1 },
+              { id: 'question-b', code: 4, order: 2 },
+            ],
+          },
+        ],
+      },
+      {
+        id: 'tab-3',
+        code: 3,
+        order: 2,
+        title: 'Tab Three',
+        sections: [
+          {
+            id: 'section-4',
+            code: 4,
+            order: 1,
+            title: 'Section Four',
+            questions: [
+              { id: 'question-7', code: 7, order: 1 },
+              { id: 'question-8', code: 8, order: 2 },
+              { id: 'question-9', code: 9, order: 3 },
+            ],
+          },
+          {
+            id: 'section-x',
+            code: 9,
+            order: 2,
+            title: 'Section X',
+            questions: [
+              { id: 'question-10', code: 10, order: 1 },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+];
+
+test('normalizePath resolves the same question for deep links and stored ids after reordering', () => {
+  const structure = buildStructure();
+  const deepLink = fromCode('5.3.4.8');
+  const storedLocation = {
+    phaseId: 'phase-5',
+    tabId: 'tab-3',
+    sectionId: 'section-4',
+    questionId: 'question-8',
+  };
+
+  const initialDeepLinkPath = normalizePath(deepLink, structure);
+  const initialStoredPath = normalizePath(storedLocation, structure);
+
+  assert.equal(initialDeepLinkPath.questionId, 'question-8');
+  assert.equal(initialStoredPath.questionId, 'question-8');
+
+  // Reorder tabs and sections to ensure we rely on stable ids/codes rather than index order.
+  structure[0].tabs.reverse();
+  structure[0].tabs.forEach((tab) => {
+    tab.sections.reverse();
+  });
+
+  const reorderedDeepLinkPath = normalizePath(deepLink, structure);
+  const reorderedStoredPath = normalizePath(storedLocation, structure);
+
+  assert.equal(reorderedDeepLinkPath.questionId, 'question-8');
+  assert.equal(reorderedStoredPath.questionId, 'question-8');
+
+  assert.equal(reorderedDeepLinkPath.phase, 5);
+  assert.equal(reorderedStoredPath.tab, 3);
+});


### PR DESCRIPTION
## Summary
- add explicit codes and ordering metadata to the self-discovery question bank and expose navigation config for the phase/tab
- update the navigation structure, resolvers, and context/component consumers to resolve paths by stable ids before falling back to codes
- add a node-based regression test that ensures deep links and stored paths still land on the same question after reordering sample data

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cae40d1eac832196b5c9e1199dcec9